### PR TITLE
Add retry mechanism when calling the llm

### DIFF
--- a/cmd/examples/llm/openai/retry/README.md
+++ b/cmd/examples/llm/openai/retry/README.md
@@ -1,0 +1,75 @@
+# OpenAI Retry Example
+
+This example demonstrates how to use the retry mechanism with the OpenAI client in the agent-sdk-go.
+
+## Features Demonstrated
+
+1. Configuring retry policy with custom parameters:
+   - Maximum attempts
+   - Initial retry interval
+   - Backoff coefficient
+   - Maximum interval
+
+2. Using retry with different OpenAI operations:
+   - Text generation
+   - Chat completion
+   - Different retry configurations
+
+## Running the Example
+
+1. Set your OpenAI API key:
+```bash
+export OPENAI_API_KEY=your-api-key
+```
+
+2. Run the example:
+```bash
+go run main.go
+```
+
+## Example Output
+
+The example will show:
+- Debug logs for each retry attempt
+- Backoff intervals between retries
+- Success/failure messages
+- Final responses from OpenAI
+
+## Retry Configuration Options
+
+The example demonstrates two different retry configurations:
+
+1. Default configuration:
+```go
+openai.WithRetry(
+    retry.WithMaxAttempts(3),
+    retry.WithInitialInterval(time.Second),
+    retry.WithBackoffCoefficient(2.0),
+    retry.WithMaximumInterval(time.Second*30),
+)
+```
+
+2. Aggressive configuration (for demonstration):
+```go
+openai.WithRetry(
+    retry.WithMaxAttempts(5),
+    retry.WithInitialInterval(time.Millisecond*500),
+    retry.WithBackoffCoefficient(1.5),
+    retry.WithMaximumInterval(time.Second*5),
+)
+```
+
+## Understanding the Retry Mechanism
+
+The retry mechanism provides:
+- Exponential backoff between retries
+- Configurable maximum attempts
+- Context-aware cancellation
+- Detailed logging of retry attempts
+- Flexible configuration options
+
+The debug logs will show:
+- Each retry attempt
+- Current and next retry intervals
+- Success/failure of each attempt
+- Final outcome of the operation 

--- a/cmd/examples/llm/openai/retry/main.go
+++ b/cmd/examples/llm/openai/retry/main.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/llm"
+	"github.com/Ingenimax/agent-sdk-go/pkg/llm/openai"
+	"github.com/Ingenimax/agent-sdk-go/pkg/logging"
+	"github.com/Ingenimax/agent-sdk-go/pkg/retry"
+)
+
+func main() {
+	// Create a logger
+	logger := logging.New()
+	ctx := context.Background()
+
+	// Get API key from environment
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		logger.Error(ctx, "OPENAI_API_KEY environment variable is required", nil)
+		os.Exit(1)
+	}
+
+	// Create client with retry configuration
+	client := openai.NewClient(
+		apiKey,
+		openai.WithModel("gpt-4o-mini"),
+		openai.WithLogger(logger),
+		openai.WithRetry(
+			retry.WithMaxAttempts(3),
+			retry.WithInitialInterval(time.Second),
+			retry.WithBackoffCoefficient(2.0),
+			retry.WithMaximumInterval(time.Second*30),
+		),
+	)
+
+	// Example 1: Simple text generation with retry
+	logger.Info(ctx, "Example 1: Simple text generation with retry", nil)
+	resp, err := client.Generate(
+		ctx,
+		"Write a short poem about resilience",
+		openai.WithSystemMessage("You are a creative poet who writes about overcoming challenges."),
+		openai.WithTemperature(0.7),
+	)
+	if err != nil {
+		logger.Error(ctx, "Failed to generate", map[string]interface{}{"error": err.Error()})
+		os.Exit(1)
+	}
+	logger.Info(ctx, "Generated text", map[string]interface{}{"text": resp})
+
+	// Example 2: Chat with retry and custom parameters
+	logger.Info(ctx, "Example 2: Chat with retry and custom parameters", nil)
+	messages := []llm.Message{
+		{
+			Role:    "system",
+			Content: "You are a helpful assistant who provides detailed explanations.",
+		},
+		{
+			Role:    "user",
+			Content: "Explain the concept of exponential backoff in retry mechanisms.",
+		},
+	}
+
+	resp, err = client.Chat(ctx, messages, &llm.GenerateParams{
+		Temperature: 0.5,
+	})
+	if err != nil {
+		logger.Error(ctx, "Failed to chat", map[string]interface{}{"error": err.Error()})
+		os.Exit(1)
+	}
+	logger.Info(ctx, "Chat response", map[string]interface{}{"text": resp})
+
+	// Example 3: Simulating a failure scenario
+	apiKey = "invalid"
+	client = openai.NewClient(
+		apiKey,
+		openai.WithModel("gpt-4o-mini"),
+		openai.WithLogger(logger),
+		openai.WithRetry(
+			retry.WithMaxAttempts(3),
+			retry.WithInitialInterval(time.Second*5),
+			retry.WithBackoffCoefficient(2.0),
+			retry.WithMaximumInterval(time.Second*30),
+		),
+	)
+
+	resp, err = client.Generate(
+		ctx,
+		"Write a short poem about resilience",
+		openai.WithSystemMessage("You are a creative poet who writes about overcoming challenges."),
+		openai.WithTemperature(0.7),
+	)
+	if err != nil {
+		logger.Error(ctx, "Failed to generate", map[string]interface{}{"error": err.Error()})
+		os.Exit(1)
+	}
+	logger.Info(ctx, "Generated text", map[string]interface{}{"text": resp})
+
+}

--- a/pkg/retry/executor.go
+++ b/pkg/retry/executor.go
@@ -1,0 +1,89 @@
+package retry
+
+import (
+	"context"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/logging"
+)
+
+// Executor handles the execution of operations with retries
+type Executor struct {
+	policy *Policy
+	logger logging.Logger
+}
+
+// NewExecutor creates a new retry executor with the given policy
+func NewExecutor(policy *Policy) *Executor {
+	return &Executor{
+		policy: policy,
+		logger: logging.New(),
+	}
+}
+
+// Execute executes the given operation with retries based on the policy
+func (e *Executor) Execute(ctx context.Context, operation func() error) error {
+	var lastErr error
+	attempt := int32(0)
+	currentInterval := e.policy.InitialInterval
+
+	for attempt < e.policy.MaximumAttempts {
+		select {
+		case <-ctx.Done():
+			e.logger.Debug(ctx, "Context cancelled during retry", map[string]interface{}{
+				"attempt": attempt,
+				"error":   ctx.Err(),
+			})
+			return ctx.Err()
+		default:
+			e.logger.Debug(ctx, "Attempting operation", map[string]interface{}{
+				"attempt":      attempt + 1,
+				"max_attempts": e.policy.MaximumAttempts,
+			})
+
+			if err := operation(); err == nil {
+				e.logger.Debug(ctx, "Operation succeeded", map[string]interface{}{
+					"attempt": attempt + 1,
+				})
+				return nil
+			} else {
+				lastErr = err
+				attempt++
+
+				if attempt >= e.policy.MaximumAttempts {
+					e.logger.Debug(ctx, "Maximum attempts reached", map[string]interface{}{
+						"attempt": attempt,
+						"error":   err.Error(),
+					})
+					break
+				}
+
+				// Calculate next backoff interval
+				nextInterval := time.Duration(float64(currentInterval) * e.policy.BackoffCoefficient)
+				if nextInterval > e.policy.MaximumInterval {
+					nextInterval = e.policy.MaximumInterval
+				}
+
+				e.logger.Debug(ctx, "Operation failed, scheduling retry", map[string]interface{}{
+					"attempt":          attempt,
+					"error":            err.Error(),
+					"current_interval": currentInterval,
+					"next_interval":    nextInterval,
+				})
+
+				select {
+				case <-ctx.Done():
+					e.logger.Debug(ctx, "Context cancelled during retry delay", map[string]interface{}{
+						"attempt": attempt,
+						"error":   ctx.Err(),
+					})
+					return ctx.Err()
+				case <-time.After(currentInterval):
+					currentInterval = nextInterval
+				}
+			}
+		}
+	}
+
+	return lastErr
+}

--- a/pkg/retry/policy.go
+++ b/pkg/retry/policy.go
@@ -1,0 +1,58 @@
+package retry
+
+import "time"
+
+// Policy defines the retry policy configuration
+type Policy struct {
+	InitialInterval    time.Duration
+	BackoffCoefficient float64
+	MaximumInterval    time.Duration
+	MaximumAttempts    int32
+}
+
+// Option represents a retry policy option
+type Option func(*Policy)
+
+// WithInitialInterval sets the initial interval for retries
+func WithInitialInterval(interval time.Duration) Option {
+	return func(p *Policy) {
+		p.InitialInterval = interval
+	}
+}
+
+// WithBackoffCoefficient sets the backoff coefficient
+func WithBackoffCoefficient(coefficient float64) Option {
+	return func(p *Policy) {
+		p.BackoffCoefficient = coefficient
+	}
+}
+
+// WithMaximumInterval sets the maximum interval between retries
+func WithMaximumInterval(interval time.Duration) Option {
+	return func(p *Policy) {
+		p.MaximumInterval = interval
+	}
+}
+
+// WithMaxAttempts sets the maximum number of retry attempts
+func WithMaxAttempts(attempts int32) Option {
+	return func(p *Policy) {
+		p.MaximumAttempts = attempts
+	}
+}
+
+// NewPolicy creates a new retry policy with default values
+func NewPolicy(opts ...Option) *Policy {
+	policy := &Policy{
+		InitialInterval:    time.Second,       // Default 1s
+		BackoffCoefficient: 2.0,               // Default exponential backoff
+		MaximumInterval:    time.Second * 100, // Default 100s
+		MaximumAttempts:    3,                 // Default 3 attempts
+	}
+
+	for _, opt := range opts {
+		opt(policy)
+	}
+
+	return policy
+}


### PR DESCRIPTION
This PR introduces a configurable retry mechanism for the OpenAI client, enabling automatic retries for failed LLM requests. This improves reliability when transient errors (e.g., rate limits, network issues) occur.

```go
openai.WithRetry(
    retry.WithMaxAttempts(3),
    retry.WithInitialInterval(time.Second),
    retry.WithBackoffCoefficient(2.0),
    retry.WithMaximumInterval(time.Second*30),
)
```

It will be useful in case of the OpenAI request fails.