### PR TITLE
Fix streaming order - remote agent

### DIFF
--- a/pkg/grpc/client/remote_agent.go
+++ b/pkg/grpc/client/remote_agent.go
@@ -46,6 +46,7 @@ type RemoteAgentClient struct {
 	errorHandlers    []func(error)
 	completeHandlers []func()
 	handlersMu       sync.RWMutex
+	
 }
 
 // RemoteAgentConfig configures the remote agent client
@@ -564,8 +565,8 @@ func (r *RemoteAgentClient) Stream(ctx context.Context, input string) error {
 	}
 
 	for event := range events {
-		// Execute handlers asynchronously to prevent blocking
-		go r.executeHandlers(event)
+		// Execute handlers synchronously to preserve event ordering
+		r.executeHandlers(event)
 	}
 
 	return nil
@@ -579,8 +580,8 @@ func (r *RemoteAgentClient) StreamWithAuth(ctx context.Context, input string, au
 	}
 
 	for event := range events {
-		// Execute handlers asynchronously to prevent blocking
-		go r.executeHandlers(event)
+		// Execute handlers synchronously to preserve event ordering
+		r.executeHandlers(event)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

- Fixed OpenAI streaming content arriving out of order by changing async handler execution to synchronous
- Removed async goroutines (go r.executeHandlers(event)) that were causing race conditions in event processing
- Events now process sequentially, preserving correct content order for streaming responses
- Removed logs
- add logger to agent

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
