### PR TITLE
Support for streamable client transport

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -223,9 +223,9 @@ func NewHTTPServer(ctx context.Context, config HTTPServerConfig) (interfaces.MCP
 			Endpoint: config.BaseURL,
 		}
 	default:
-		// Default to Streamable if type is not recognized
-		logger.Warn(ctx, "Server protocol type is not set, defaulting to Streamable", map[string]interface{}{})
-		transport = &mcp.StreamableClientTransport{
+		// Default to SSE if type is not recognized
+		logger.Warn(ctx, "Server protocol type is not set, defaulting to SSE", map[string]interface{}{})
+		transport = &mcp.SSEClientTransport{
 			Endpoint: config.BaseURL,
 		}
 	}


### PR DESCRIPTION
## Description
After adopting official MCP SDK, seems only SSE Client is used for connecting to MCP servers. Due to this, agent is not able to connect with MCP servers supporting only streamable HTTP protocol.

Fixes # (issue)

## Type of change
With this change, users can set protocol type (streamable vs sse) in the configuration. Based on type, appropriate client transport will be initialized. Since SSE is considered legacy by the latest MCP spec, streamable is set as default when type is not set. 

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Tested all 3 scenarios with Agent SDK:
1. Protocol is set to **sse**
2. Protocol is set to **streamable**
3. No Protocol set 

Though, use case still does not work properly due to https://github.com/Ingenimax/agent-sdk-go/issues/160
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
