### PR TITLE
fix: prevent JSON concatenation by summarizing structured responses in conversation history

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -884,9 +884,9 @@ func formatHistoryIntoPrompt(history []interfaces.Message) string {
 		// Handle assistant messages that contain structured JSON output
 		content := msg.Content
 		if msg.Role == "assistant" && isStructuredJSONResponse(content) {
-			// For structured JSON responses, summarize instead of showing full JSON
+			// For structured JSON responses, convert to human-readable format instead of showing full JSON
 			// This prevents LLM confusion that leads to concatenated JSON responses
-			content = summarizeStructuredResponse(content)
+			content = convertToHumanReadable(content)
 		}
 
 		// Add role marker and content
@@ -908,9 +908,9 @@ func isStructuredJSONResponse(content string) bool {
 	return strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}")
 }
 
-// summarizeStructuredResponse converts a JSON response to a human-readable summary
+// convertToHumanReadable converts a JSON response to a human-readable format
 // to avoid confusing the LLM with raw JSON in conversation history
-func summarizeStructuredResponse(jsonContent string) string {
+func convertToHumanReadable(jsonContent string) string {
 	// Try to parse the JSON to extract key information
 	var jsonMap map[string]interface{}
 	if err := json.Unmarshal([]byte(jsonContent), &jsonMap); err != nil {

--- a/pkg/agent/format_test.go
+++ b/pkg/agent/format_test.go
@@ -30,7 +30,7 @@ func TestFormatHistoryIntoPrompt(t *testing.T) {
 				{Role: "tool", Content: `{"query": "list all EKS clusters", "output": "eks-cluster-1"}`},
 				{Role: "assistant", Content: "You have eks-cluster-1 available"},
 			},
-			expected: "USER: list which clusters I have available\n\nASSISTANT: [AI reasoning: User is requesting a list of available clusters]\n\nTOOL: {\"query\": \"list all EKS clusters\", \"output\": \"eks-cluster-1\"}\n\nASSISTANT: You have eks-cluster-1 available",
+			expected: "USER: list which clusters I have available\n\nASSISTANT: [AI: reasoning: User is requesting a list of available clusters]\n\nTOOL: {\"query\": \"list all EKS clusters\", \"output\": \"eks-cluster-1\"}\n\nASSISTANT: You have eks-cluster-1 available",
 		},
 		{
 			name: "single message",

--- a/pkg/agent/format_test.go
+++ b/pkg/agent/format_test.go
@@ -30,7 +30,7 @@ func TestFormatHistoryIntoPrompt(t *testing.T) {
 				{Role: "tool", Content: `{"query": "list all EKS clusters", "output": "eks-cluster-1"}`},
 				{Role: "assistant", Content: "You have eks-cluster-1 available"},
 			},
-			expected: "USER: list which clusters I have available\n\nASSISTANT: {\"reasoning\":[\"User is requesting a list of available clusters\"]}\n\nTOOL: {\"query\": \"list all EKS clusters\", \"output\": \"eks-cluster-1\"}\n\nASSISTANT: You have eks-cluster-1 available",
+			expected: "USER: list which clusters I have available\n\nASSISTANT: [AI reasoning: User is requesting a list of available clusters]\n\nTOOL: {\"query\": \"list all EKS clusters\", \"output\": \"eks-cluster-1\"}\n\nASSISTANT: You have eks-cluster-1 available",
 		},
 		{
 			name: "single message",

--- a/pkg/agent/json_summarization_test.go
+++ b/pkg/agent/json_summarization_test.go
@@ -45,7 +45,7 @@ func TestIsStructuredJSONResponse(t *testing.T) {
 	}
 }
 
-func TestSummarizeStructuredResponse(t *testing.T) {
+func TestConvertToHumanReadable(t *testing.T) {
 	tests := []struct {
 		name           string
 		json           string
@@ -104,21 +104,21 @@ func TestSummarizeStructuredResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := summarizeStructuredResponse(tt.json)
+			got := convertToHumanReadable(tt.json)
 
 			if got == "" {
-				t.Error("summarizeStructuredResponse() returned empty string")
+				t.Error("convertToHumanReadable() returned empty string")
 			}
 
 			for _, want := range tt.wantContains {
 				if !strings.Contains(got, want) {
-					t.Errorf("summarizeStructuredResponse() = %q, want to contain %q", got, want)
+					t.Errorf("convertToHumanReadable() = %q, want to contain %q", got, want)
 				}
 			}
 
 			for _, notWant := range tt.wantNotContain {
 				if strings.Contains(got, notWant) {
-					t.Errorf("summarizeStructuredResponse() = %q, want to NOT contain %q", got, notWant)
+					t.Errorf("convertToHumanReadable() = %q, want to NOT contain %q", got, notWant)
 				}
 			}
 
@@ -126,7 +126,7 @@ func TestSummarizeStructuredResponse(t *testing.T) {
 			if tt.name == "large object limited to 3 fields" {
 				commaCount := strings.Count(got, ",")
 				if commaCount > 2 {
-					t.Errorf("summarizeStructuredResponse() should limit to 3 fields (2 commas max), got %d commas", commaCount)
+					t.Errorf("convertToHumanReadable() should limit to 3 fields (2 commas max), got %d commas", commaCount)
 				}
 			}
 		})

--- a/pkg/agent/json_summarization_test.go
+++ b/pkg/agent/json_summarization_test.go
@@ -1,0 +1,280 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/Ingenimax/agent-sdk-go/pkg/memory"
+	"github.com/Ingenimax/agent-sdk-go/pkg/multitenancy"
+	"github.com/Ingenimax/agent-sdk-go/pkg/structuredoutput"
+)
+
+func TestIsStructuredJSONResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{"valid simple object", `{"key": "value"}`, true},
+		{"valid with whitespace", `  {"key": "value"}  `, true},
+		{"valid nested", `{"a":{"b":{"c":"d"}}}`, true},
+		{"valid with arrays", `{"items":["a","b","c"],"count":3}`, true},
+		{"valid with numbers", `{"id":123,"price":45.67,"active":true}`, true},
+		{"valid empty object", `{}`, true},
+		{"valid with newlines", "{\n  \"key\": \"value\"\n}", true},
+		{"invalid plain text", "This is just text", false},
+		{"invalid partial start", `{"incomplete`, false},
+		{"invalid partial end", `incomplete"}`, false},
+		{"invalid array", `["not", "an", "object"]`, false},
+		{"invalid empty string", "", false},
+		{"invalid whitespace", "   ", false},
+		{"invalid number", "123", false},
+		{"invalid boolean", "true", false},
+		{"invalid string", `"just a string"`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStructuredJSONResponse(tt.content); got != tt.expected {
+				t.Errorf("isStructuredJSONResponse() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSummarizeStructuredResponse(t *testing.T) {
+	tests := []struct {
+		name           string
+		json           string
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name:           "agent response with reasoning",
+			json:           `{"reasoning":["User needs help"],"status":"active","priority":"high"}`,
+			wantContains:   []string{"[AI:", "reasoning: User needs help", "status: active", "priority: high"},
+			wantNotContain: []string{"{", "}", `["User needs help"]`},
+		},
+		{
+			name:           "custom fields",
+			json:           `{"thoughts":["Analyzing"],"confidence":0.9,"action":"respond"}`,
+			wantContains:   []string{"[AI:", "thoughts: Analyzing", "confidence: 0.9", "action: respond"},
+			wantNotContain: []string{"{", "}", `["Analyzing"]`},
+		},
+		{
+			name:           "mixed data types",
+			json:           `{"message":"Hello","count":42,"enabled":true,"score":95.5}`,
+			wantContains:   []string{"[AI:", "message: Hello"},
+			wantNotContain: []string{"{", "}", `"message"`},
+		},
+		{
+			name:           "empty arrays skipped",
+			json:           `{"empty_array":[],"valid_field":"content","another_empty":[]}`,
+			wantContains:   []string{"[AI:", "valid_field: content"},
+			wantNotContain: []string{"empty_array", "another_empty"},
+		},
+		{
+			name:           "null and empty values skipped",
+			json:           `{"null_field":null,"empty_string":"","valid":"content"}`,
+			wantContains:   []string{"[AI:", "valid: content"},
+			wantNotContain: []string{"null_field", "empty_string"},
+		},
+		{
+			name:           "invalid json returns fallback",
+			json:           `{invalid json}`,
+			wantContains:   []string{"[Generated structured response]"},
+			wantNotContain: []string{"{invalid json}"},
+		},
+		{
+			name:           "empty object returns fallback",
+			json:           `{}`,
+			wantContains:   []string{"[Generated structured response]"},
+			wantNotContain: []string{},
+		},
+		{
+			name:           "large object limited to 3 fields",
+			json:           `{"field1":"value1","field2":"value2","field3":"value3","field4":"value4","field5":"value5"}`,
+			wantContains:   []string{"[AI:"},
+			wantNotContain: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeStructuredResponse(tt.json)
+
+			if got == "" {
+				t.Error("summarizeStructuredResponse() returned empty string")
+			}
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("summarizeStructuredResponse() = %q, want to contain %q", got, want)
+				}
+			}
+
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(got, notWant) {
+					t.Errorf("summarizeStructuredResponse() = %q, want to NOT contain %q", got, notWant)
+				}
+			}
+
+			// Verify field limit for large JSON
+			if tt.name == "large object limited to 3 fields" {
+				commaCount := strings.Count(got, ",")
+				if commaCount > 2 {
+					t.Errorf("summarizeStructuredResponse() should limit to 3 fields (2 commas max), got %d commas", commaCount)
+				}
+			}
+		})
+	}
+}
+
+func TestConversationHistoryFormatting(t *testing.T) {
+	tests := []struct {
+		name     string
+		history  []interfaces.Message
+		wantJSON bool
+	}{
+		{
+			name: "json response gets summarized",
+			history: []interfaces.Message{
+				{Role: "user", Content: "Deploy the model"},
+				{Role: "assistant", Content: `{"reasoning":["Analyzing deployment request"],"status":"active"}`},
+				{Role: "user", Content: "Use GCP"},
+			},
+			wantJSON: false,
+		},
+		{
+			name: "plain text response unchanged",
+			history: []interfaces.Message{
+				{Role: "user", Content: "Hello"},
+				{Role: "assistant", Content: "Hi there!"},
+			},
+			wantJSON: false,
+		},
+		{
+			name: "tool messages unchanged",
+			history: []interfaces.Message{
+				{Role: "tool", Content: `{"result": "success"}`},
+			},
+			wantJSON: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatted := formatHistoryIntoPrompt(tt.history)
+
+			if tt.wantJSON {
+				if !strings.Contains(formatted, "{") {
+					t.Error("formatHistoryIntoPrompt() should preserve JSON in tool messages")
+				}
+			} else {
+				if strings.Contains(formatted, `"reasoning":`) {
+					t.Error("formatHistoryIntoPrompt() should not contain raw JSON from assistant messages")
+				}
+			}
+		})
+	}
+}
+
+type mockLLMForIntegration struct {
+	callCount int
+}
+
+func (m *mockLLMForIntegration) Name() string            { return "mock-llm" }
+func (m *mockLLMForIntegration) SupportsStreaming() bool { return false }
+
+func (m *mockLLMForIntegration) Generate(ctx context.Context, prompt string, options ...interfaces.GenerateOption) (string, error) {
+	m.callCount++
+
+	if m.callCount == 1 {
+		return `{"task":"analyze","status":"progress","details":"Processing"}`, nil
+	}
+
+	// Should see summary in prompt, not raw JSON
+	if strings.Contains(prompt, `"task":"analyze"`) {
+		// This would be the bug - concatenated response
+		return `{"task":"analyze","status":"progress"}{"task":"respond","status":"complete"}`, nil
+	}
+
+	// With fix, should see summary format
+	return `{"task":"respond","status":"complete","details":"Finished"}`, nil
+}
+
+func (m *mockLLMForIntegration) GenerateWithTools(ctx context.Context, prompt string, tools []interfaces.Tool, options ...interfaces.GenerateOption) (string, error) {
+	return m.Generate(ctx, prompt, options...)
+}
+
+func TestJSONConcatenationPrevention(t *testing.T) {
+	mockLLM := &mockLLMForIntegration{}
+	conversationMemory := memory.NewConversationBuffer()
+
+	type TestResponse struct {
+		Task    string `json:"task"`
+		Status  string `json:"status"`
+		Details string `json:"details"`
+	}
+	responseFormat := structuredoutput.NewResponseFormat(TestResponse{})
+
+	agent, err := NewAgent(
+		WithLLM(mockLLM),
+		WithMemory(conversationMemory),
+		WithResponseFormat(*responseFormat),
+		WithSystemPrompt("You are a helpful assistant."),
+		WithRequirePlanApproval(false),
+	)
+	if err != nil {
+		t.Fatalf("NewAgent() error = %v", err)
+	}
+
+	ctx := context.Background()
+	ctx = multitenancy.WithOrgID(ctx, "test-org")
+	ctx = memory.WithConversationID(ctx, "test-conversation")
+
+	// First call
+	response1, err := agent.Run(ctx, "Analyze this request")
+	if err != nil {
+		t.Fatalf("agent.Run() error = %v", err)
+	}
+
+	var firstResp TestResponse
+	if err := json.Unmarshal([]byte(response1), &firstResp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	// Second call
+	response2, err := agent.Run(ctx, "Continue processing")
+	if err != nil {
+		t.Fatalf("agent.Run() error = %v", err)
+	}
+
+	// Verify response is single JSON object, not concatenated
+	var secondResp TestResponse
+	if err := json.Unmarshal([]byte(response2), &secondResp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	jsonCount := strings.Count(response2, `"task":`)
+	if jsonCount != 1 {
+		t.Errorf("Expected single JSON object, got %d objects in: %s", jsonCount, response2)
+	}
+
+	// Verify conversation history contains summaries
+	history, err := conversationMemory.GetMessages(ctx)
+	if err != nil {
+		t.Fatalf("GetMessages() error = %v", err)
+	}
+
+	formatted := formatHistoryIntoPrompt(history)
+	if strings.Contains(formatted, `"task":"analyze"`) {
+		t.Error("Conversation history should not contain raw JSON")
+	}
+	if !strings.Contains(formatted, "[AI:") {
+		t.Error("Conversation history should contain summarized responses")
+	}
+}

--- a/pkg/llm/anthropic/client.go
+++ b/pkg/llm/anthropic/client.go
@@ -512,7 +512,7 @@ Important instructions:
 	response := strings.Join(contentText, "\n")
 
 	// For structured output, prepend the opening brace that was used as prefill
-	if params.ResponseFormat != nil {
+	if params.ResponseFormat != nil && !strings.HasPrefix(strings.TrimSpace(response), "{") {
 		response = "{" + response
 	}
 


### PR DESCRIPTION
## Description
Fixes a bug where LLMs would intermittently return concatenated JSON responses (~10% occurrence rate) when using structured output in multi-turn conversations.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)