### PR TITLE
Add DisplayName and Internal params to Tools

### DIFF
--- a/examples/advanced_agent_streaming/main.go
+++ b/examples/advanced_agent_streaming/main.go
@@ -27,8 +27,16 @@ func (t *MockDataTool) Name() string {
 	return "market_data_lookup"
 }
 
+func (t *MockDataTool) DisplayName() string {
+	return "Market Data Lookup"
+}
+
 func (t *MockDataTool) Description() string {
 	return "Lookup specific market data and statistics for analysis"
+}
+
+func (t *MockDataTool) Internal() bool {
+	return false
 }
 
 func (t *MockDataTool) Parameters() map[string]interfaces.ParameterSpec {
@@ -82,8 +90,17 @@ func (t *TrendAnalysisTool) Name() string {
 	return "trend_analysis"
 }
 
+// DisplayName implements interfaces.ToolWithDisplayName.DisplayName
+func (t *TrendAnalysisTool) DisplayName() string {
+	return "Trend Analysis"
+}
+
 func (t *TrendAnalysisTool) Description() string {
 	return "Analyze market trends and provide forecasting insights"
+}
+
+func (t *TrendAnalysisTool) Internal() bool {
+	return false
 }
 
 func (t *TrendAnalysisTool) Parameters() map[string]interfaces.ParameterSpec {

--- a/examples/llm/gemini/main.go
+++ b/examples/llm/gemini/main.go
@@ -63,8 +63,16 @@ func (t *ExampleTool) Name() string {
 	return "get_weather"
 }
 
+func (t *ExampleTool) DisplayName() string {
+	return "Weather Tool"
+}
+
 func (t *ExampleTool) Description() string {
 	return "Get current weather information for a location"
+}
+
+func (t *ExampleTool) Internal() bool {
+	return false
 }
 
 func (t *ExampleTool) Parameters() map[string]interfaces.ParameterSpec {

--- a/examples/streaming_intermediate_messages/main.go
+++ b/examples/streaming_intermediate_messages/main.go
@@ -59,8 +59,16 @@ func (c *CalculatorTool) Name() string {
 	return "calculator"
 }
 
+func (c *CalculatorTool) DisplayName() string {
+	return "Calculator"
+}
+
 func (c *CalculatorTool) Description() string {
 	return "Performs basic arithmetic operations"
+}
+
+func (c *CalculatorTool) Internal() bool {
+	return false
 }
 
 func (c *CalculatorTool) Parameters() map[string]interfaces.ParameterSpec {

--- a/pkg/agent/custom_functions_test.go
+++ b/pkg/agent/custom_functions_test.go
@@ -52,8 +52,16 @@ func (m *mockTool) Name() string {
 	return m.name
 }
 
+func (m *mockTool) DisplayName() string {
+	return m.name
+}
+
 func (m *mockTool) Description() string {
 	return m.description
+}
+
+func (m *mockTool) Internal() bool {
+	return false
 }
 
 func (m *mockTool) Run(ctx context.Context, input string) (string, error) {

--- a/pkg/agent/tool_memory_test.go
+++ b/pkg/agent/tool_memory_test.go
@@ -55,10 +55,25 @@ func (m *MockLLMWithTools) GenerateWithTools(ctx context.Context, prompt string,
 	if params.Memory != nil && len(tools) > 0 {
 		// Simulate calling the first tool
 		tool := tools[0]
+		// Get display name and internal flag using type assertions
+		var displayName string
+		var internal bool
+		if toolWithDisplayName, ok := tool.(interfaces.ToolWithDisplayName); ok {
+			displayName = toolWithDisplayName.DisplayName()
+		}
+		if displayName == "" {
+			displayName = tool.Name()
+		}
+		if internalTool, ok := tool.(interfaces.InternalTool); ok {
+			internal = internalTool.Internal()
+		}
+
 		toolCall := interfaces.ToolCall{
-			ID:        "test-tool-call-1",
-			Name:      tool.Name(),
-			Arguments: `{"test": "value"}`,
+			ID:          "test-tool-call-1",
+			Name:        tool.Name(),
+			DisplayName: displayName,
+			Internal:    internal,
+			Arguments:   `{"test": "value"}`,
 		}
 
 		// Store assistant message with tool call
@@ -113,8 +128,16 @@ func (m *MockTool) Name() string {
 	return m.name
 }
 
+func (m *MockTool) DisplayName() string {
+	return m.name
+}
+
 func (m *MockTool) Description() string {
 	return m.description
+}
+
+func (m *MockTool) Internal() bool {
+	return false
 }
 
 func (m *MockTool) Parameters() map[string]interfaces.ParameterSpec {

--- a/pkg/grpc/client/remote_agent.go
+++ b/pkg/grpc/client/remote_agent.go
@@ -710,22 +710,26 @@ func convertPbToStreamEvent(resp *pb.RunStreamResponse) interfaces.AgentStreamEv
 		event.Type = interfaces.AgentEventToolCall
 		if resp.ToolCall != nil {
 			event.ToolCall = &interfaces.ToolCallEvent{
-				ID:        resp.ToolCall.Id,
-				Name:      resp.ToolCall.Name,
-				Arguments: resp.ToolCall.Arguments,
-				Result:    resp.ToolCall.Result,
-				Status:    resp.ToolCall.Status,
+				ID:          resp.ToolCall.Id,
+				Name:        resp.ToolCall.Name,
+				DisplayName: resp.ToolCall.DisplayName,
+				Internal:    resp.ToolCall.Internal,
+				Arguments:   resp.ToolCall.Arguments,
+				Result:      resp.ToolCall.Result,
+				Status:      resp.ToolCall.Status,
 			}
 		}
 	case pb.EventType_EVENT_TYPE_TOOL_RESULT:
 		event.Type = interfaces.AgentEventToolResult
 		if resp.ToolCall != nil {
 			event.ToolCall = &interfaces.ToolCallEvent{
-				ID:        resp.ToolCall.Id,
-				Name:      resp.ToolCall.Name,
-				Arguments: resp.ToolCall.Arguments,
-				Result:    resp.ToolCall.Result,
-				Status:    resp.ToolCall.Status,
+				ID:          resp.ToolCall.Id,
+				Name:        resp.ToolCall.Name,
+				DisplayName: resp.ToolCall.DisplayName,
+				Internal:    resp.ToolCall.Internal,
+				Arguments:   resp.ToolCall.Arguments,
+				Result:      resp.ToolCall.Result,
+				Status:      resp.ToolCall.Status,
 			}
 		}
 	case pb.EventType_EVENT_TYPE_ERROR:

--- a/pkg/grpc/pb/agent.pb.go
+++ b/pkg/grpc/pb/agent.pb.go
@@ -7,12 +7,11 @@
 package pb
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -387,9 +386,11 @@ type ToolCall struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Arguments     string                 `protobuf:"bytes,3,opt,name=arguments,proto3" json:"arguments,omitempty"`
-	Result        string                 `protobuf:"bytes,4,opt,name=result,proto3" json:"result,omitempty"`
-	Status        string                 `protobuf:"bytes,5,opt,name=status,proto3" json:"status,omitempty"` // "received", "executing", "completed", "error"
+	DisplayName   string                 `protobuf:"bytes,3,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	Internal      bool                   `protobuf:"varint,4,opt,name=internal,proto3" json:"internal,omitempty"`
+	Arguments     string                 `protobuf:"bytes,5,opt,name=arguments,proto3" json:"arguments,omitempty"`
+	Result        string                 `protobuf:"bytes,6,opt,name=result,proto3" json:"result,omitempty"`
+	Status        string                 `protobuf:"bytes,7,opt,name=status,proto3" json:"status,omitempty"` // "received", "executing", "completed", "error"
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -436,6 +437,20 @@ func (x *ToolCall) GetName() string {
 		return x.Name
 	}
 	return ""
+}
+
+func (x *ToolCall) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
+func (x *ToolCall) GetInternal() bool {
+	if x != nil {
+		return x.Internal
+	}
+	return false
 }
 
 func (x *ToolCall) GetArguments() string {
@@ -1222,13 +1237,15 @@ const file_agent_proto_rawDesc = "" +
 	"\ttimestamp\x18\b \x01(\x03R\ttimestamp\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"|\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xbb\x01\n" +
 	"\bToolCall\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1c\n" +
-	"\targuments\x18\x03 \x01(\tR\targuments\x12\x16\n" +
-	"\x06result\x18\x04 \x01(\tR\x06result\x12\x16\n" +
-	"\x06status\x18\x05 \x01(\tR\x06status\"\x11\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12!\n" +
+	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\x12\x1a\n" +
+	"\binternal\x18\x04 \x01(\bR\binternal\x12\x1c\n" +
+	"\targuments\x18\x05 \x01(\tR\targuments\x12\x16\n" +
+	"\x06result\x18\x06 \x01(\tR\x06result\x12\x16\n" +
+	"\x06status\x18\a \x01(\tR\x06status\"\x11\n" +
 	"\x0fMetadataRequest\"\x99\x02\n" +
 	"\x10MetadataResponse\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
@@ -1319,7 +1336,7 @@ var (
 
 func file_agent_proto_rawDescGZIP() []byte {
 	file_agent_proto_rawDescOnce.Do(func() {
-		file_agent_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_agent_proto_rawDesc), len(file_agent_proto_rawDesc))) // #nosec G103
+		file_agent_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_agent_proto_rawDesc), len(file_agent_proto_rawDesc)))
 	})
 	return file_agent_proto_rawDescData
 }
@@ -1396,7 +1413,7 @@ func file_agent_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agent_proto_rawDesc), len(file_agent_proto_rawDesc)), // #nosec G103
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agent_proto_rawDesc), len(file_agent_proto_rawDesc)),
 			NumEnums:      2,
 			NumMessages:   23,
 			NumExtensions: 0,

--- a/pkg/grpc/pb/agent.pb.go
+++ b/pkg/grpc/pb/agent.pb.go
@@ -1336,6 +1336,7 @@ var (
 
 func file_agent_proto_rawDescGZIP() []byte {
 	file_agent_proto_rawDescOnce.Do(func() {
+		// #nosec G103 - unsafe usage is safe in protobuf-generated code
 		file_agent_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_agent_proto_rawDesc), len(file_agent_proto_rawDesc)))
 	})
 	return file_agent_proto_rawDescData
@@ -1413,6 +1414,7 @@ func file_agent_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
+			// #nosec G103 - unsafe usage is safe in protobuf-generated code
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agent_proto_rawDesc), len(file_agent_proto_rawDesc)),
 			NumEnums:      2,
 			NumMessages:   23,

--- a/pkg/grpc/pb/agent_grpc.pb.go
+++ b/pkg/grpc/pb/agent_grpc.pb.go
@@ -8,7 +8,6 @@ package pb
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/pkg/grpc/proto/agent.proto
+++ b/pkg/grpc/proto/agent.proto
@@ -78,9 +78,11 @@ enum EventType {
 message ToolCall {
     string id = 1;
     string name = 2;
-    string arguments = 3;
-    string result = 4;
-    string status = 5; // "received", "executing", "completed", "error"
+    string display_name = 3;
+    bool internal = 4;
+    string arguments = 5;
+    string result = 6;
+    string status = 7; // "received", "executing", "completed", "error"
 }
 
 // MetadataRequest for getting agent metadata

--- a/pkg/grpc/server/agent_server.go
+++ b/pkg/grpc/server/agent_server.go
@@ -183,11 +183,13 @@ func (s *AgentServer) RunStream(req *pb.RunRequest, stream pb.AgentService_RunSt
 		// Add tool call info if present
 		if event.ToolCall != nil {
 			response.ToolCall = &pb.ToolCall{
-				Id:        event.ToolCall.ID,
-				Name:      event.ToolCall.Name,
-				Arguments: event.ToolCall.Arguments,
-				Result:    event.ToolCall.Result,
-				Status:    event.ToolCall.Status,
+				Id:          event.ToolCall.ID,
+				Name:        event.ToolCall.Name,
+				DisplayName: event.ToolCall.DisplayName,
+				Internal:    event.ToolCall.Internal,
+				Arguments:   event.ToolCall.Arguments,
+				Result:      event.ToolCall.Result,
+				Status:      event.ToolCall.Status,
 			}
 		}
 

--- a/pkg/interfaces/memory.go
+++ b/pkg/interfaces/memory.go
@@ -24,9 +24,11 @@ type Message struct {
 
 // ToolCall represents a tool call made by the assistant
 type ToolCall struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
+	Internal    bool   `json:"internal,omitempty"`
+	Arguments   string `json:"arguments"`
 }
 
 // Memory represents a memory store for agent conversations

--- a/pkg/interfaces/streaming.go
+++ b/pkg/interfaces/streaming.go
@@ -76,11 +76,13 @@ const (
 
 // ToolCallEvent represents a tool call in streaming context
 type ToolCallEvent struct {
-	ID        string `json:"id,omitempty"`
-	Name      string `json:"name"`
-	Arguments string `json:"arguments,omitempty"`
-	Result    string `json:"result,omitempty"`
-	Status    string `json:"status"` // "starting", "executing", "completed", "error"
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
+	Internal    bool   `json:"internal,omitempty"`
+	Arguments   string `json:"arguments,omitempty"`
+	Result      string `json:"result,omitempty"`
+	Status      string `json:"status"` // "starting", "executing", "completed", "error"
 }
 
 // StreamConfig contains configuration for streaming behavior

--- a/pkg/interfaces/tool.go
+++ b/pkg/interfaces/tool.go
@@ -20,6 +20,21 @@ type Tool interface {
 	Execute(ctx context.Context, args string) (string, error)
 }
 
+// ToolWithDisplayName is an optional interface that tools can implement
+// to provide a human-friendly display name
+type ToolWithDisplayName interface {
+	// DisplayName returns a human-friendly name for the tool
+	DisplayName() string
+}
+
+// InternalTool is an optional interface that tools can implement
+// to indicate they should be hidden from users
+type InternalTool interface {
+	// Internal returns true if this tool's usage should be hidden from users
+	// This can be used to filter tool calls in OnToolCall or other display contexts
+	Internal() bool
+}
+
 // ParameterSpec defines the specification for a tool parameter
 type ParameterSpec struct {
 	// Type is the data type of the parameter (string, number, boolean, etc.)

--- a/pkg/llm/gemini/client_test.go
+++ b/pkg/llm/gemini/client_test.go
@@ -26,8 +26,16 @@ func (t *MockTool) Name() string {
 	return t.name
 }
 
+func (t *MockTool) DisplayName() string {
+	return t.name
+}
+
 func (t *MockTool) Description() string {
 	return t.description
+}
+
+func (t *MockTool) Internal() bool {
+	return false
 }
 
 func (t *MockTool) Parameters() map[string]interfaces.ParameterSpec {

--- a/pkg/llm/ollama/client_test.go
+++ b/pkg/llm/ollama/client_test.go
@@ -316,8 +316,16 @@ func (t *mockTool) Name() string {
 	return t.name
 }
 
+func (t *mockTool) DisplayName() string {
+	return t.name
+}
+
 func (t *mockTool) Description() string {
 	return t.description
+}
+
+func (t *mockTool) Internal() bool {
+	return false
 }
 
 func (t *mockTool) Run(ctx context.Context, input string) (string, error) {

--- a/pkg/llm/openai/client_test.go
+++ b/pkg/llm/openai/client_test.go
@@ -449,8 +449,16 @@ func (m *mockTool) Name() string {
 	return m.name
 }
 
+func (m *mockTool) DisplayName() string {
+	return m.name
+}
+
 func (m *mockTool) Description() string {
 	return m.description
+}
+
+func (m *mockTool) Internal() bool {
+	return false
 }
 
 func (m *mockTool) Parameters() map[string]interfaces.ParameterSpec {

--- a/pkg/mcp/adapters.go
+++ b/pkg/mcp/adapters.go
@@ -38,9 +38,19 @@ func (a *MCPToolAdapter) Name() string {
 	return a.toolName
 }
 
+// DisplayName implements interfaces.ToolWithDisplayName.DisplayName
+func (a *MCPToolAdapter) DisplayName() string {
+	return a.toolName
+}
+
 // Description returns the description of the tool
 func (a *MCPToolAdapter) Description() string {
 	return a.toolDesc
+}
+
+// Internal implements interfaces.InternalTool.Internal
+func (a *MCPToolAdapter) Internal() bool {
+	return false
 }
 
 // Run executes the tool with the given input

--- a/pkg/mcp/lazy.go
+++ b/pkg/mcp/lazy.go
@@ -158,9 +158,19 @@ func (t *LazyMCPTool) Name() string {
 	return t.name
 }
 
+// DisplayName implements interfaces.ToolWithDisplayName.DisplayName
+func (t *LazyMCPTool) DisplayName() string {
+	return t.name
+}
+
 // Description returns a description of what the tool does
 func (t *LazyMCPTool) Description() string {
 	return t.description
+}
+
+// Internal implements interfaces.InternalTool.Internal
+func (t *LazyMCPTool) Internal() bool {
+	return false
 }
 
 // getServer gets the MCP server, initializing it if necessary

--- a/pkg/mcp/tool.go
+++ b/pkg/mcp/tool.go
@@ -33,9 +33,21 @@ func (t *MCPTool) Name() string {
 	return t.name
 }
 
+// DisplayName implements interfaces.ToolWithDisplayName.DisplayName
+func (t *MCPTool) DisplayName() string {
+	// MCP tools can use the name as display name
+	return t.name
+}
+
 // Description returns a description of what the tool does
 func (t *MCPTool) Description() string {
 	return t.description
+}
+
+// Internal implements interfaces.InternalTool.Internal
+func (t *MCPTool) Internal() bool {
+	// MCP tools are typically visible to users
+	return false
 }
 
 // Run executes the tool with the given input

--- a/pkg/microservice/factory.go
+++ b/pkg/microservice/factory.go
@@ -416,11 +416,13 @@ func convertGRPCResponseToAgentEvent(response *pb.RunStreamResponse) interfaces.
 
 		if response.ToolCall != nil {
 			event.ToolCall = &interfaces.ToolCallEvent{
-				ID:        response.ToolCall.Id,
-				Name:      response.ToolCall.Name,
-				Arguments: response.ToolCall.Arguments,
-				Result:    response.ToolCall.Result,
-				Status:    response.ToolCall.Status,
+				ID:          response.ToolCall.Id,
+				Name:        response.ToolCall.Name,
+				DisplayName: response.ToolCall.DisplayName,
+				Internal:    response.ToolCall.Internal,
+				Arguments:   response.ToolCall.Arguments,
+				Result:      response.ToolCall.Result,
+				Status:      response.ToolCall.Status,
 			}
 		}
 

--- a/pkg/tools/agent_tool.go
+++ b/pkg/tools/agent_tool.go
@@ -75,12 +75,22 @@ func (at *AgentTool) Name() string {
 	return at.name
 }
 
+// DisplayName implements interfaces.ToolWithDisplayName.DisplayName
+func (at *AgentTool) DisplayName() string {
+	return fmt.Sprintf("%s Agent", at.agent.GetName())
+}
+
 // Description returns the description of what the tool does
 func (at *AgentTool) Description() string {
 	if at.description != "" {
 		return at.description
 	}
 	return fmt.Sprintf("Delegate task to %s agent for specialized handling", at.agent.GetName())
+}
+
+// Internal implements interfaces.InternalTool.Internal
+func (at *AgentTool) Internal() bool {
+	return false
 }
 
 // Parameters returns the parameters that the tool accepts

--- a/pkg/tools/calculator/calculator.go
+++ b/pkg/tools/calculator/calculator.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Calculator implements a simple calculator tool
-type Calculator struct{}
+type Calculator struct {}
 
 // Input represents the input for the calculator tool
 type Input struct {
@@ -29,9 +29,19 @@ func (c *Calculator) Name() string {
 	return "calculator"
 }
 
+// DisplayName implements interfaces.ToolWithDisplayName.DisplayName
+func (c *Calculator) DisplayName() string {
+	return "Calculator"
+}
+
 // Description implements interfaces.Tool.Description
 func (c *Calculator) Description() string {
 	return "Perform mathematical calculations (add, subtract, multiply, divide, exponents)"
+}
+
+// Internal implements interfaces.InternalTool.Internal
+func (c *Calculator) Internal() bool {
+	return false
 }
 
 // Parameters implements interfaces.Tool.Parameters

--- a/pkg/tools/github/github_content_extractor.go
+++ b/pkg/tools/github/github_content_extractor.go
@@ -41,9 +41,19 @@ func (gct *GitHubContentExtractorTool) Name() string {
 	return "github_content_extractor"
 }
 
+// DisplayName implements interfaces.ToolWithDisplayName.DisplayName
+func (gct *GitHubContentExtractorTool) DisplayName() string {
+	return "GitHub Content Extractor"
+}
+
 // Description returns the description of the tool
 func (gct *GitHubContentExtractorTool) Description() string {
 	return "Extracts content from GitHub repositories based on file patterns"
+}
+
+// Internal implements interfaces.InternalTool.Internal
+func (gct *GitHubContentExtractorTool) Internal() bool {
+	return false
 }
 
 // Parameters returns the parameters that the tool accepts

--- a/pkg/tools/huggingface/huggingface.go
+++ b/pkg/tools/huggingface/huggingface.go
@@ -70,9 +70,19 @@ func (t *Tool) Name() string {
 	return "huggingface_search"
 }
 
+// DisplayName implements interfaces.ToolWithDisplayName.DisplayName
+func (t *Tool) DisplayName() string {
+	return "Hugging Face Search"
+}
+
 // Description returns a description of what the tool does
 func (t *Tool) Description() string {
 	return "Search Hugging Face for AI models matching the given query"
+}
+
+// Internal implements interfaces.InternalTool.Internal
+func (t *Tool) Internal() bool {
+	return false
 }
 
 // Parameters returns the parameters that the tool accepts

--- a/pkg/tools/websearch/websearch.go
+++ b/pkg/tools/websearch/websearch.go
@@ -57,9 +57,19 @@ func (t *Tool) Name() string {
 	return "web_search"
 }
 
+// DisplayName implements interfaces.ToolWithDisplayName.DisplayName
+func (t *Tool) DisplayName() string {
+	return "Web Search"
+}
+
 // Description returns a description of what the tool does
 func (t *Tool) Description() string {
 	return "Search the web for information on a given query"
+}
+
+// Internal implements interfaces.InternalTool.Internal
+func (t *Tool) Internal() bool {
+	return false
 }
 
 // Parameters returns the parameters that the tool accepts


### PR DESCRIPTION
## Description

  1. Created Optional Interfaces

  - ToolWithDisplayName interface for tools that want to provide a human-friendly name
  - InternalTool interface for tools that want to indicate they should be hidden from users

  2. Updated Streaming Code with Type Assertions

  - Modified handleToolCallStreaming in pkg/agent/streaming.go to use type assertions
  - Provides default values when optional methods aren't implemented:
    - DisplayName: Falls back to tool.Name() if not implemented or empty
    - Internal: Defaults to false if not implemented

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
