### PR TITLE
feat(llm): add structured output support for streaming across providers

### DIFF
--- a/pkg/llm/azureopenai/streaming.go
+++ b/pkg/llm/azureopenai/streaming.go
@@ -691,6 +691,21 @@ func (c *AzureOpenAIClient) GenerateWithToolsStream(
 			finalStreamParams.Temperature = openai.Float(params.LLMConfig.Temperature)
 		}
 
+		// Add structured output if specified
+		if params.ResponseFormat != nil {
+			jsonSchema := shared.ResponseFormatJSONSchemaJSONSchemaParam{
+				Name:   params.ResponseFormat.Name,
+				Schema: params.ResponseFormat.Schema,
+			}
+
+			finalStreamParams.ResponseFormat = openai.ChatCompletionNewParamsResponseFormatUnion{
+				OfJSONSchema: &shared.ResponseFormatJSONSchemaParam{
+					Type:       "json_schema",
+					JSONSchema: jsonSchema,
+				},
+			}
+		}
+
 		// Add other parameters
 		if params.LLMConfig != nil {
 			// Reasoning models don't support top_p parameter

--- a/pkg/llm/openai/streaming.go
+++ b/pkg/llm/openai/streaming.go
@@ -679,6 +679,21 @@ func (c *OpenAIClient) GenerateWithToolsStream(
 			finalStreamParams.Temperature = openai.Float(params.LLMConfig.Temperature)
 		}
 
+		// Add structured output if specified
+		if params.ResponseFormat != nil {
+			jsonSchema := shared.ResponseFormatJSONSchemaJSONSchemaParam{
+				Name:   params.ResponseFormat.Name,
+				Schema: params.ResponseFormat.Schema,
+			}
+
+			finalStreamParams.ResponseFormat = openai.ChatCompletionNewParamsResponseFormatUnion{
+				OfJSONSchema: &shared.ResponseFormatJSONSchemaParam{
+					Type:       "json_schema",
+					JSONSchema: jsonSchema,
+				},
+			}
+		}
+
 		// Add other parameters
 		if params.LLMConfig != nil {
 			// Reasoning models don't support top_p parameter


### PR DESCRIPTION
## Description
This PR enhances the LLM streaming capabilities with structured output support across multiple providers and adds token limit controls for Gemini.

## Changes
- **Anthropic**: Enhanced streaming with schema-aware final messages that include detailed JSON structure examples
- **OpenAI & Azure OpenAI**: Added ResponseFormat support for streaming final calls
- **Gemini**: 
  - Added WithMaxOutputTokens option for better token control
  - Applied max output tokens configuration across all generation methods
  - Added ResponseFormat support to streaming final calls

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- All existing unit tests pass (go test ./...)
- go mod verify confirms all dependencies are valid
- golangci-lint passes with no issues
- Manual testing with structured output examples

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Notes
- govulncheck reported 2 vulnerabilities in Go standard library (1.24.5), fixed in 1.24.6 - unrelated to this PR