### PR TITLE
fix: ensure max_tokens > budget_tokens when reasoning is enabled

### DIFF
--- a/pkg/llm/anthropic/client.go
+++ b/pkg/llm/anthropic/client.go
@@ -435,11 +435,18 @@ Example output:
 Return only the JSON object, with no additional text or markdown formatting.`, prompt, string(schemaJSON), string(exampleStr))
 	}
 
+	// Calculate maxTokens - must be greater than budget_tokens when reasoning is enabled
+	maxTokens := 2048 // default
+	if params.LLMConfig != nil && params.LLMConfig.EnableReasoning && params.LLMConfig.ReasoningBudget > 0 {
+		// Ensure max_tokens > budget_tokens for reasoning
+		maxTokens = params.LLMConfig.ReasoningBudget + 4000 // Add buffer for actual response
+	}
+
 	// Create request
 	req := CompletionRequest{
 		Model:       c.Model,
 		Messages:    messages,
-		MaxTokens:   2048,
+		MaxTokens:   maxTokens,
 		Temperature: params.LLMConfig.Temperature,
 		TopP:        params.LLMConfig.TopP,
 	}
@@ -929,13 +936,20 @@ func (c *AnthropicClient) GenerateWithTools(ctx context.Context, prompt string, 
 	// Build messages with memory and current prompt
 	messages := c.buildMessagesWithMemory(ctx, prompt, params)
 
+	// Calculate maxTokens - must be greater than budget_tokens when reasoning is enabled
+	maxTokens := 2048 // default
+	if params.LLMConfig != nil && params.LLMConfig.EnableReasoning && params.LLMConfig.ReasoningBudget > 0 {
+		// Ensure max_tokens > budget_tokens for reasoning
+		maxTokens = params.LLMConfig.ReasoningBudget + 4000 // Add buffer for actual response
+	}
+
 	// Iterative tool calling loop
 	for iteration := 0; iteration < maxIterations; iteration++ {
 		// Create request
 		req := CompletionRequest{
 			Model:       c.Model,
 			Messages:    messages,
-			MaxTokens:   2048,
+			MaxTokens:   maxTokens,
 			Temperature: params.LLMConfig.Temperature,
 			TopP:        params.LLMConfig.TopP,
 			Tools:       anthropicTools,
@@ -1401,7 +1415,7 @@ func (c *AnthropicClient) GenerateWithTools(ctx context.Context, prompt string, 
 	finalReq := CompletionRequest{
 		Model:       c.Model,
 		Messages:    messages,
-		MaxTokens:   2048,
+		MaxTokens:   maxTokens, // Use calculated maxTokens (already accounts for reasoning budget)
 		Temperature: params.LLMConfig.Temperature,
 		TopP:        params.LLMConfig.TopP,
 		Tools:       nil, // No tools for final call


### PR DESCRIPTION
When using Claude's extended thinking feature via Vertex AI, the API requires max_tokens to be greater than thinking.budget_tokens. Previously, max_tokens was hardcoded to 2048 in the non-streaming code paths, which caused API errors when ReasoningBudget was set to values greater than 2048.

This fix calculates maxTokens dynamically as ReasoningBudget + 4000 when reasoning is enabled, matching the behavior already present in streaming.go.

Fixes the error: 'max_tokens must be greater than thinking.budget_tokens'

Affected functions:
- generateInternal (Generate)
- GenerateWithTools (both iteration loop and final request)

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
