### PR TITLE
feat: add Token field for HTTP authentication in LazyMCP configuration

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -29,6 +29,7 @@ type LazyMCPConfig struct {
 	Args    []string
 	Env     []string
 	URL     string
+	Token   string // Bearer token for HTTP authentication
 	Tools   []LazyMCPToolConfig
 }
 
@@ -1020,6 +1021,7 @@ func (a *Agent) createLazyMCPTools() []interfaces.Tool {
 			Args:    config.Args,
 			Env:     config.Env,
 			URL:     config.URL,
+			Token:   config.Token,
 		}
 
 		// If no specific tools are defined, discover all tools from the server

--- a/pkg/agent/mcp_config.go
+++ b/pkg/agent/mcp_config.go
@@ -270,6 +270,7 @@ func applyMCPConfig(a *Agent, config *MCPConfiguration) {
 				Name:  serverName,
 				Type:  "http",
 				URL:   serverConfig.URL,
+				Token: serverConfig.Token,    // Preserve token for lazy initialization
 				Tools: []LazyMCPToolConfig{}, // Will discover dynamically
 			}
 			lazyConfigs = append(lazyConfigs, lazyConfig)

--- a/pkg/mcp/lazy.go
+++ b/pkg/mcp/lazy.go
@@ -76,6 +76,7 @@ func (cache *LazyMCPServerCache) getOrCreateServer(ctx context.Context, config L
 	case "http":
 		server, err = NewHTTPServer(ctx, HTTPServerConfig{
 			BaseURL: config.URL,
+			Token:   config.Token,
 		})
 	default:
 		return nil, fmt.Errorf("unsupported MCP server type: %s", config.Type)
@@ -151,6 +152,7 @@ type LazyMCPServerConfig struct {
 	Args    []string
 	Env     []string
 	URL     string
+	Token   string // Bearer token for HTTP authentication
 }
 
 // LazyMCPTool is a tool that initializes its MCP server on first use


### PR DESCRIPTION
- Introduced Token field in LazyMCPConfig and LazyMCPServerConfig for Bearer token support.
- Updated createLazyMCPTools and applyMCPConfig functions to handle the new Token field.
- Ensured compatibility with HTTP server initialization by passing the Token parameter.

This enhancement improves security by allowing authenticated requests to the MCP server.

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
