### PR TITLE
fix: skip unnecessary final LLM call when model returns without tool …

### DIFF
--- a/pkg/llm/openai/streaming.go
+++ b/pkg/llm/openai/streaming.go
@@ -337,6 +337,9 @@ func (c *OpenAIClient) GenerateWithToolsStream(
 		// Track captured content for final iteration replay if filtering is enabled
 		var capturedContentEvents []interfaces.StreamEvent
 
+		// Track if we got a complete response (no tool calls)
+		gotCompleteResponse := false
+
 		// Iterative tool calling loop
 		for iteration := 0; iteration < maxIterations; iteration++ {
 			iterationHasContent := false
@@ -566,6 +569,7 @@ func (c *OpenAIClient) GenerateWithToolsStream(
 						},
 					}
 				}
+				gotCompleteResponse = true
 				break // Exit the iteration loop
 			}
 
@@ -672,6 +676,18 @@ func (c *OpenAIClient) GenerateWithToolsStream(
 			for _, contentEvent := range capturedContentEvents {
 				eventChan <- contentEvent
 			}
+		}
+
+		// If we got a complete response (no tool calls), skip the final synthesis call
+		if gotCompleteResponse {
+			c.logger.Debug(ctx, "Skipping final synthesis call - already got complete response", map[string]interface{}{
+				"maxIterations": maxIterations,
+			})
+			eventChan <- interfaces.StreamEvent{
+				Type:      interfaces.StreamEventMessageStop,
+				Timestamp: time.Now(),
+			}
+			return
 		}
 
 		// Final call without tools to get synthesis


### PR DESCRIPTION
…calls

When the LLM returns a response without requesting any tools, the streaming implementations for OpenAI, AzureOpenAI, and DeepSeek were incorrectly making a second "final synthesis" call. This happened because the code used `break` to exit the iteration loop but then continued to the "Maximum iterations reached" block regardless of why the loop exited.

The fix adds a `gotCompleteResponse` flag (matching the pattern already used in Anthropic's streaming implementation) to track when the model returns without tool calls, and skips the final synthesis call in that case.

This eliminates the unnecessary second LLM call and the misleading "Maximum iterations reached" log message when iterations were not actually exhausted.

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
