### PR TITLE
feat: add DataStore field to Agent and expose in config endpoint

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -50,6 +50,7 @@ type CustomRunStreamFunction func(ctx context.Context, input string, agent *Agen
 type Agent struct {
 	llm                  interfaces.LLM
 	memory               interfaces.Memory
+	datastore            interfaces.DataStore // DataStore for persistent data storage (PostgreSQL, Supabase, etc.)
 	tools                []interfaces.Tool
 	subAgents            []*Agent // Sub-agents that can be called as tools
 	orgID                string
@@ -103,6 +104,13 @@ func WithLLM(llm interfaces.LLM) Option {
 func WithMemory(memory interfaces.Memory) Option {
 	return func(a *Agent) {
 		a.memory = memory
+	}
+}
+
+// WithDataStore sets the datastore for the agent
+func WithDataStore(datastore interfaces.DataStore) Option {
+	return func(a *Agent) {
+		a.datastore = datastore
 	}
 }
 
@@ -1583,6 +1591,16 @@ func (a *Agent) GetLLM() interfaces.LLM {
 // GetMemory returns the memory instance (for use in custom functions)
 func (a *Agent) GetMemory() interfaces.Memory {
 	return a.memory
+}
+
+// GetDataStore returns the datastore instance
+func (a *Agent) GetDataStore() interfaces.DataStore {
+	return a.datastore
+}
+
+// SetDataStore sets the datastore for the agent
+func (a *Agent) SetDataStore(datastore interfaces.DataStore) {
+	a.datastore = datastore
 }
 
 // GetAllConversations returns all conversation IDs from memory

--- a/pkg/microservice/ui_server_fixes_test.go
+++ b/pkg/microservice/ui_server_fixes_test.go
@@ -231,7 +231,7 @@ func TestHTTPServerWithUI_getMemoryInfo(t *testing.T) {
 			setupMemory: func() interfaces.Memory {
 				return memory.NewConversationBuffer()
 			},
-			expectedType:   "conversation",
+			expectedType:   "buffer", // ConversationBuffer now correctly detected as "buffer"
 			expectedStatus: "active",
 			hasEntryCount:  false, // Memory starts empty until messages are added
 		},


### PR DESCRIPTION
- Add datastore field to Agent struct for persistent storage (PostgreSQL, Supabase)
- Add WithDataStore() option for agent creation
- Add GetDataStore() and SetDataStore() methods
- Update /api/v1/agent/config endpoint to include datastore info
- Add getDataStoreInfo() and detectDataStoreType() helpers
- Fix detectMemoryType() to return actual memory type (redis, buffer) instead of generic "conversation"
- Update test to expect "buffer" instead of "conversation" for ConversationBuffer

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
