### PR TITLE
fix: add memoryConfig fallback when memory instance is nil

### DIFF
--- a/pkg/microservice/ui_server.go
+++ b/pkg/microservice/ui_server.go
@@ -1048,6 +1048,16 @@ func (h *HTTPServerWithUI) getMemoryInfo() MemoryInfo {
 	// For local agents, check memory directly
 	mem := h.agent.GetMemory()
 	if mem == nil {
+		// Check if there's a memory config that indicates the type
+		// even if the instance hasn't been created yet
+		if memConfig := h.agent.GetMemoryConfig(); memConfig != nil {
+			if memType, ok := memConfig["type"].(string); ok && memType != "" {
+				return MemoryInfo{
+					Type:   memType,
+					Status: "configured", // Memory is configured but not instantiated
+				}
+			}
+		}
 		return MemoryInfo{
 			Type:   "none",
 			Status: "inactive",


### PR DESCRIPTION
When memory is configured via YAML but the instance hasn't been instantiated yet, getMemoryInfo() now checks memoryConfig to return the configured memory type with status "configured" instead of incorrectly returning "none".

## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
