### PR TITLE
fix env var expand and add more logs to MCP initialization

### DIFF
--- a/pkg/agent/mcp_config.go
+++ b/pkg/agent/mcp_config.go
@@ -244,7 +244,16 @@ func applyMCPConfig(a *Agent, config *MCPConfiguration) {
 			var envSlice []string
 			for key, value := range serverConfig.Env {
 				// Expand environment variables in the value
-				resolvedValue := os.ExpandEnv(value)
+				// Use SDK's ExpandEnv which checks OS env vars, .env files, AND config service values
+				resolvedValue := ExpandEnv(value)
+
+				// Debug logging to track env var expansion
+				if resolvedValue == "" && value != "" {
+					fmt.Printf("[MCP Config] WARNING: Failed to expand %s='%s' (resulted in empty string)\n", key, value)
+				} else {
+					fmt.Printf("[MCP Config] DEBUG: Expanded %s='%s' -> '%s'\n", key, value, resolvedValue)
+				}
+
 				envSlice = append(envSlice, fmt.Sprintf("%s=%s", key, resolvedValue))
 
 			}


### PR DESCRIPTION
## Description

This PR adds more logs do MCP initialization and fix env var expand for config server.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
