### PR TITLE
Added support for HTTP Transport type in MCP server configuration

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -23,14 +23,15 @@ import (
 
 // LazyMCPConfig holds configuration for lazy MCP server initialization
 type LazyMCPConfig struct {
-	Name    string
-	Type    string // "stdio" or "http"
-	Command string
-	Args    []string
-	Env     []string
-	URL     string
-	Token   string // Bearer token for HTTP authentication
-	Tools   []LazyMCPToolConfig
+	Name              string
+	Type              string // "stdio" or "http"
+	Command           string
+	Args              []string
+	Env               []string
+	URL               string
+	Token             string // Bearer token for HTTP authentication
+	Tools             []LazyMCPToolConfig
+	HttpTransportMode string // "sse" or "streamable"
 }
 
 // LazyMCPToolConfig holds configuration for a lazy MCP tool
@@ -1080,13 +1081,14 @@ func (a *Agent) createLazyMCPTools() []interfaces.Tool {
 
 		// Create lazy server config
 		lazyServerConfig := mcp.LazyMCPServerConfig{
-			Name:    config.Name,
-			Type:    config.Type,
-			Command: config.Command,
-			Args:    config.Args,
-			Env:     config.Env,
-			URL:     config.URL,
-			Token:   config.Token,
+			Name:              config.Name,
+			Type:              config.Type,
+			Command:           config.Command,
+			Args:              config.Args,
+			Env:               config.Env,
+			URL:               config.URL,
+			Token:             config.Token,
+			HttpTransportMode: config.HttpTransportMode,
 		}
 
 		// If no specific tools are defined, discover all tools from the server

--- a/pkg/mcp/builder.go
+++ b/pkg/mcp/builder.go
@@ -300,9 +300,10 @@ func (b *Builder) initializeServer(ctx context.Context, config LazyMCPServerConf
 		u.RawQuery = q.Encode()
 
 		server, err = NewHTTPServerWithRetry(ctx, HTTPServerConfig{
-			BaseURL: u.String(),
-			Token:   token,
-			Logger:  b.logger,
+			BaseURL:      u.String(),
+			Token:        token,
+			Logger:       b.logger,
+			ProtocolType: ServerProtocolType(config.HttpTransportMode),
 		}, &RetryConfig{
 			MaxAttempts:       b.retryOptions.MaxAttempts,
 			InitialDelay:      b.retryOptions.InitialDelay,

--- a/pkg/mcp/lazy.go
+++ b/pkg/mcp/lazy.go
@@ -95,8 +95,9 @@ func (cache *LazyMCPServerCache) getOrCreateServer(ctx context.Context, config L
 		})
 	case "http":
 		server, err = NewHTTPServer(ctx, HTTPServerConfig{
-			BaseURL: config.URL,
-			Token:   config.Token,
+			BaseURL:      config.URL,
+			Token:        config.Token,
+			ProtocolType: ServerProtocolType(config.HttpTransportMode),
 		})
 	default:
 		return nil, fmt.Errorf("unsupported MCP server type: %s", config.Type)
@@ -166,13 +167,14 @@ func (cache *LazyMCPServerCache) getOrCreateServer(ctx context.Context, config L
 
 // LazyMCPServerConfig holds configuration for creating an MCP server on demand
 type LazyMCPServerConfig struct {
-	Name    string
-	Type    string // "stdio" or "http"
-	Command string
-	Args    []string
-	Env     []string
-	URL     string
-	Token   string // Bearer token for HTTP authentication
+	Name              string
+	Type              string // "stdio" or "http"
+	Command           string
+	Args              []string
+	Env               []string
+	URL               string
+	Token             string // Bearer token for HTTP authentication
+	HttpTransportMode string // "sse" or "streamable"
 }
 
 // LazyMCPTool is a tool that initializes its MCP server on first use
@@ -406,11 +408,11 @@ func (t *LazyMCPTool) Run(ctx context.Context, input string) (string, error) {
 				errorMsg = fmt.Sprintf("%v", content)
 			}
 			t.logger.Error(ctx, "[MCP TOOL ERROR] MCP server returned error (unknown type)", map[string]interface{}{
-				"tool_name":    t.name,
-				"server_name":  t.serverConfig.Name,
-				"error_type":   fmt.Sprintf("%T", content),
-				"error":        errorMsg,
-				"raw_content":  content,
+				"tool_name":   t.name,
+				"server_name": t.serverConfig.Name,
+				"error_type":  fmt.Sprintf("%T", content),
+				"error":       errorMsg,
+				"raw_content": content,
 			})
 		}
 		return "", fmt.Errorf("MCP tool error from server '%s': %s", t.serverConfig.Name, errorMsg)


### PR DESCRIPTION
## Description
Currently, MCP clients default to SSE transport. So, MCP server with only Streamable HTTP transport support can not be used with SDK.

Fixes # (issue)
Added new field in the server configuration as below:
`
"mcpServers": {
    "testmcp": {
      "url": "http://localhost:8905/mcp",
      "type": "http",
      "httpTransportMode": "streamable" // Allowed values: sse/SSE or streamable/Streamable
    }
  }
`
## Type of change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Ran go tests in pkg.
## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
