### PR TITLE
fix: MessageStartData mismatch

### DIFF
--- a/pkg/llm/anthropic/sse.go
+++ b/pkg/llm/anthropic/sse.go
@@ -17,14 +17,16 @@ type AnthropicSSEEvent struct {
 	Data json.RawMessage `json:"data,omitempty"`
 }
 
-// MessageStart event data
+// MessageStartData represents the message_start event data.
 type MessageStartData struct {
 	Type    string `json:"type"`
-	ID      string `json:"id"`
-	Role    string `json:"role"`
-	Content []any  `json:"content"`
-	Model   string `json:"model"`
-	Usage   Usage  `json:"usage"`
+	Message struct {
+		ID      string `json:"id"`
+		Role    string `json:"role"`
+		Content []any  `json:"content"`
+		Model   string `json:"model"`
+		Usage   Usage  `json:"usage"`
+	} `json:"message"`
 }
 
 // ContentBlockStart event data
@@ -133,10 +135,10 @@ func (c *AnthropicClient) convertAnthropicEventToStreamEvent(event *AnthropicSSE
 		}
 
 		streamEvent.Type = interfaces.StreamEventMessageStart
-		streamEvent.Metadata["message_id"] = msgStart.ID
-		streamEvent.Metadata["model"] = msgStart.Model
-		streamEvent.Metadata["role"] = msgStart.Role
-		streamEvent.Metadata["usage"] = msgStart.Usage
+		streamEvent.Metadata["message_id"] = msgStart.Message.ID
+		streamEvent.Metadata["model"] = msgStart.Message.Model
+		streamEvent.Metadata["role"] = msgStart.Message.Role
+		streamEvent.Metadata["usage"] = msgStart.Message.Usage
 
 	case "content_block_start":
 		var blockStart ContentBlockStartData


### PR DESCRIPTION
## Description

Fixed a bug where token usage was not being extracted from Anthropic/Bedrock streaming events due to incorrect JSON struct mapping in `MessageStartData`.

https://platform.claude.com/docs/en/build-with-claude/streaming#streaming-with-sdks

### Root Cause

The `MessageStartData` struct expected message fields at the **top level**, but per [Anthropic's official streaming documentation](https://docs.anthropic.com/claude/reference/messages-streaming), they are nested inside a `"message"` field:

**Actual SSE format from Anthropic API:**
```json
{
  "type": "message_start",
  "message": {
    "id": "msg_1nZdL29xx5MUA1yADyHTEsnR8uuvGzszyY",
    "role": "assistant",
    "model": "claude-opus-4-20250514",
    "usage": { "input_tokens": 25, "output_tokens": 1 }
  }
}
```

**Old struct (incorrect):**
```go
type MessageStartData struct {
    Type  string `json:"type"`
    ID    string `json:"id"`      // ❌ Expected at top level
    Usage Usage  `json:"usage"`   // ❌ Expected at top level - always {0, 0}
}
```

**Fixed struct:**
```go
type MessageStartData struct {
    Type    string `json:"type"`
    Message struct {
        ID    string `json:"id"`    // ✓ Correctly nested
        Usage Usage  `json:"usage"` // ✓ Now extracts actual values
    } `json:"message"`
}
```

### Proof

```
Actual SSE: {"type":"message_start","message":{"usage":{"input_tokens":25}}}

OLD struct parsing:  Usage.InputTokens = 0   (WRONG)
NEW struct parsing:  Usage.InputTokens = 25  (CORRECT)
```

Fixes # (streaming token usage not exposed to consumers)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. **Unit tests updated and passing:**
   ```bash
   go test ./pkg/llm/anthropic/... -v
   ```

2. **All existing tests pass:**
   ```bash
   go test ./pkg/... -count=1
   ```

3. **Manual verification with real Anthropic/Bedrock streaming** - confirmed `event.Metadata["usage"]` now contains actual token values instead of zeros.

4. **JSON unmarshaling proof test:**
   ```go
   // Parsing actual SSE format
   json.Unmarshal(`{"type":"message_start","message":{"usage":{"input_tokens":25}}}`, &msgStart)
   // OLD: msgStart.Usage.InputTokens == 0
   // NEW: msgStart.Message.Usage.InputTokens == 25
   ```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Files Changed

| File | Change |
|------|--------|
| `pkg/llm/anthropic/sse.go` | Fixed `MessageStartData` struct to match actual Anthropic SSE format |
| `pkg/llm/anthropic/sse_test.go` | Updated tests to use correct SSE format |