### PR TITLE
Ability to filter tools for MCP Servers through config

### DIFF
--- a/pkg/agent/mcp_config.go
+++ b/pkg/agent/mcp_config.go
@@ -21,6 +21,7 @@ type MCPServerConfig struct {
 	URL               string            `json:"url,omitempty" yaml:"url,omitempty"`
 	Token             string            `json:"token,omitempty" yaml:"token,omitempty"`
 	HttpTransportMode string            `json:"httpTransportMode,omitempty" yaml:"httpTransportMode,omitempty"` // "sse" or "streamable"
+	AllowedTools      []string          `json:"allowedTools,omitempty" yaml:"allowedTools,omitempty"`
 }
 
 // MCPDiscoveredServerInfo represents metadata discovered from the server at runtime
@@ -254,12 +255,13 @@ func applyMCPConfig(a *Agent, config *MCPConfiguration, configVars map[string]st
 			}
 
 			lazyConfig := LazyMCPConfig{
-				Name:    serverName,
-				Type:    "stdio",
-				Command: serverConfig.Command,
-				Args:    serverConfig.Args,
-				Env:     envSlice,
-				Tools:   []LazyMCPToolConfig{}, // Will discover dynamically
+				Name:         serverName,
+				Type:         "stdio",
+				Command:      serverConfig.Command,
+				Args:         serverConfig.Args,
+				Env:          envSlice,
+				Tools:        []LazyMCPToolConfig{}, // Will discover dynamically
+				AllowedTools: serverConfig.AllowedTools,
 			}
 			lazyConfigs = append(lazyConfigs, lazyConfig)
 
@@ -271,11 +273,12 @@ func applyMCPConfig(a *Agent, config *MCPConfiguration, configVars map[string]st
 			}
 
 			lazyConfig := LazyMCPConfig{
-				Name:  serverName,
-				Type:  "http",
-				URL:   serverConfig.URL,
-				Token: serverConfig.Token,    // Preserve token for lazy initialization
-				Tools: []LazyMCPToolConfig{}, // Will discover dynamically
+				Name:         serverName,
+				Type:         "http",
+				URL:          serverConfig.URL,
+				Token:        serverConfig.Token,    // Preserve token for lazy initialization
+				Tools:        []LazyMCPToolConfig{}, // Will discover dynamically
+				AllowedTools: serverConfig.AllowedTools,
 			}
 			if serverConfig.HttpTransportMode != "" {
 				// handle case-insensitivity

--- a/pkg/mcp/lazy.go
+++ b/pkg/mcp/lazy.go
@@ -173,8 +173,9 @@ type LazyMCPServerConfig struct {
 	Args              []string
 	Env               []string
 	URL               string
-	Token             string // Bearer token for HTTP authentication
-	HttpTransportMode string // "sse" or "streamable"
+	Token             string   // Bearer token for HTTP authentication
+	HttpTransportMode string   // "sse" or "streamable"
+	AllowedTools      []string // List of allowed tool names for this MCP server
 }
 
 // LazyMCPTool is a tool that initializes its MCP server on first use


### PR DESCRIPTION
## Description
Today, agent detects all tools and use them in the LLM context. There is no way to provide list of whitelisted tools. 

Fixes # (issue)
With this change, users can now set list of allowed MCP server tools in the config. So, LLM can access only whitelisted tools from given MCP server.

New configuration is added to the MCP Server configuration as below:
`
{
  "mcpServers": {
    "testmcp": {
      "url": "http://localhost:8905/mcp",
      "type": "http",
      "httpTransportMode": "streamable",
      "allowedTools": ["Tool1", "Tool2"]
    }
  }
}
`

Also, replaced fmt.Print() statements with agent logger.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
All unit tests are working

## Checklist:
- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
