### PR TITLE
fix: populate Content field in StreamEventToolResult

### DIFF
--- a/pkg/llm/openai/streaming.go
+++ b/pkg/llm/openai/streaming.go
@@ -626,6 +626,7 @@ func (c *OpenAIClient) GenerateWithToolsStream(
 				eventChan <- interfaces.StreamEvent{
 					Type:      interfaces.StreamEventToolResult,
 					Timestamp: time.Now(),
+					Content:   result,
 					ToolCall: &interfaces.ToolCall{
 						ID:        toolCall.ID,
 						Name:      toolCall.Function.Name,


### PR DESCRIPTION
## Problem

When using the agent SDK with streaming tool execution, tool results were not being properly saved to memory. The tool would execute successfully and return results (e.g., `"{"location": "San Francisco", "temperature": 18, "unit": "celsius", "conditions": "Partly cloudy", "humidity": 65}"`), but the final message saved to memory would have an empty `Content` field:

```json
{
  "Role": "tool",
  "Content": "",  // ❌ Empty!
  "Metadata": {"tool_name": "get_weather"},
  "ToolCallID": "chatcmpl-tool-..."
}
```

This caused:
- Loss of tool execution results in conversation history

## Root Cause

The issue was in `pkg/llm/openai/streaming.go` around line 626. When creating the `StreamEventToolResult` event after tool execution, the `Content` field was not being populated:

```go
// Before fix:
eventChan <- interfaces.StreamEvent{
    Type:      interfaces.StreamEventToolResult,
    Timestamp: time.Now(),
    // ❌ Content field missing!
    ToolCall: &interfaces.ToolCall{...},
    Metadata: map[string]interface{}{
        "result": result,  // Result was only here
    },
}
```

Meanwhile, `pkg/agent/streaming.go` line 363 expected the result in `Content`:

```go
toolResults[llmEvent.ToolCall.ID] = llmEvent.Content  // ❌ Content was empty!
```

## Solution

Added the `Content` field to the `StreamEvent` in `pkg/llm/openai/streaming.go`:

```go
// After fix:
eventChan <- interfaces.StreamEvent{
    Type:      interfaces.StreamEventToolResult,
    Timestamp: time.Now(),
    Content:   result,  // ✅ Now populated!
    ToolCall: &interfaces.ToolCall{...},
    Metadata: map[string]interface{}{
        "result": result,
    },
}
```

## Testing

- ✅ Existing tests pass (`go test ./pkg/llm/openai/...`)
- ✅ Verified tool results now properly save to memory with correct content
- ✅ No breaking changes to public APIs

## Impact

This fix ensures that:
1. Tool execution results are correctly captured in streaming mode
2. Conversation history maintains accurate tool results
4. Agent behavior remains consistent across streaming and non-streaming modes
