### PR TITLE
feat: add Langfuse content tracing and session ID support

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,11 +91,12 @@ type Config struct {
 	Tracing struct {
 		// Langfuse configuration
 		Langfuse struct {
-			Enabled     bool
-			SecretKey   string
-			PublicKey   string
-			Host        string
-			Environment string
+			Enabled        bool
+			SecretKey      string
+			PublicKey      string
+			Host           string
+			Environment    string
+			IncludeContent bool
 		}
 
 		// OpenTelemetry configuration
@@ -190,6 +191,7 @@ func LoadFromEnv() *Config {
 	config.Tracing.Langfuse.PublicKey = getEnv("LANGFUSE_PUBLIC_KEY", "")
 	config.Tracing.Langfuse.Host = getEnv("LANGFUSE_HOST", "https://cloud.langfuse.com")
 	config.Tracing.Langfuse.Environment = getEnv("LANGFUSE_ENVIRONMENT", "development")
+	config.Tracing.Langfuse.IncludeContent = getEnvBool("LANGFUSE_INCLUDE_CONTENT", false)
 
 	config.Tracing.OpenTelemetry.Enabled = getEnvBool("OTEL_ENABLED", false)
 	config.Tracing.OpenTelemetry.ServiceName = getEnv("OTEL_SERVICE_NAME", "agent-sdk")

--- a/pkg/tracing/langfuse.go
+++ b/pkg/tracing/langfuse.go
@@ -32,6 +32,10 @@ type LangfuseConfig struct {
 
 	// Environment is the environment name (e.g., "production", "staging")
 	Environment string
+
+	// IncludeContent determines whether actual prompt/response content is included in traces
+	// When false (default), only hashes are stored for privacy
+	IncludeContent bool
 }
 
 // NewLangfuseTracer creates a new Langfuse tracer (backward compatibility wrapper)
@@ -46,11 +50,12 @@ func NewLangfuseTracer(customConfig ...LangfuseConfig) (*LangfuseTracer, error) 
 		tracerConfig = customConfig[0]
 	} else {
 		tracerConfig = LangfuseConfig{
-			Enabled:     cfg.Tracing.Langfuse.Enabled,
-			SecretKey:   cfg.Tracing.Langfuse.SecretKey,
-			PublicKey:   cfg.Tracing.Langfuse.PublicKey,
-			Host:        cfg.Tracing.Langfuse.Host,
-			Environment: cfg.Tracing.Langfuse.Environment,
+			Enabled:        cfg.Tracing.Langfuse.Enabled,
+			SecretKey:      cfg.Tracing.Langfuse.SecretKey,
+			PublicKey:      cfg.Tracing.Langfuse.PublicKey,
+			Host:           cfg.Tracing.Langfuse.Host,
+			Environment:    cfg.Tracing.Langfuse.Environment,
+			IncludeContent: cfg.Tracing.Langfuse.IncludeContent,
 		}
 	}
 

--- a/pkg/tracing/otel_langfuse.go
+++ b/pkg/tracing/otel_langfuse.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Ingenimax/agent-sdk-go/pkg/config"
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/Ingenimax/agent-sdk-go/pkg/memory"
 	"github.com/Ingenimax/agent-sdk-go/pkg/multitenancy"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -28,6 +29,7 @@ type OTELLangfuseTracer struct {
 	exporter       *otlptrace.Exporter
 	enabled        bool
 	config         LangfuseConfig
+	IncludeContent bool
 }
 
 // OTELLangfuseSpan wraps an OTEL span to implement the interfaces.Span interface
@@ -69,11 +71,12 @@ func NewOTELLangfuseTracer(customConfig ...LangfuseConfig) (*OTELLangfuseTracer,
 		tracerConfig = customConfig[0]
 	} else {
 		tracerConfig = LangfuseConfig{
-			Enabled:     cfg.Tracing.Langfuse.Enabled,
-			SecretKey:   cfg.Tracing.Langfuse.SecretKey,
-			PublicKey:   cfg.Tracing.Langfuse.PublicKey,
-			Host:        cfg.Tracing.Langfuse.Host,
-			Environment: cfg.Tracing.Langfuse.Environment,
+			Enabled:        cfg.Tracing.Langfuse.Enabled,
+			SecretKey:      cfg.Tracing.Langfuse.SecretKey,
+			PublicKey:      cfg.Tracing.Langfuse.PublicKey,
+			Host:           cfg.Tracing.Langfuse.Host,
+			Environment:    cfg.Tracing.Langfuse.Environment,
+			IncludeContent: cfg.Tracing.Langfuse.IncludeContent,
 		}
 	}
 
@@ -148,7 +151,13 @@ func NewOTELLangfuseTracer(customConfig ...LangfuseConfig) (*OTELLangfuseTracer,
 		exporter:       exporter,
 		enabled:        true,
 		config:         tracerConfig,
+		IncludeContent: tracerConfig.IncludeContent,
 	}, nil
+}
+
+// ShouldIncludeContent returns whether actual prompt/response content should be included in traces
+func (t *OTELLangfuseTracer) ShouldIncludeContent() bool {
+	return t.IncludeContent
 }
 
 // StartSpan implements interfaces.Tracer
@@ -174,6 +183,11 @@ func (t *OTELLangfuseTracer) StartSpan(ctx context.Context, name string) (contex
 	}
 	if orgID != "" {
 		attrs = append(attrs, attribute.String("langfuse.user.id", orgID))
+	}
+
+	// Add session ID from conversation context if available
+	if conversationID, ok := memory.GetConversationID(ctx); ok && conversationID != "" {
+		attrs = append(attrs, attribute.String("langfuse.session.id", conversationID))
 	}
 
 	// Add agent name if available
@@ -324,6 +338,11 @@ func (t *OTELLangfuseTracer) TraceGeneration(ctx context.Context, modelName stri
 	// Add organization ID if available
 	if orgID != "" {
 		attrs = append(attrs, attribute.String("langfuse.user.id", orgID))
+	}
+
+	// Add session ID from conversation context if available
+	if conversationID, ok := memory.GetConversationID(ctx); ok && conversationID != "" {
+		attrs = append(attrs, attribute.String("langfuse.session.id", conversationID))
 	}
 
 	// Add agent name if available
@@ -655,6 +674,11 @@ func (t *OTELLangfuseTracer) StartTraceSession(ctx context.Context, contextID st
 	// Add agent name if available
 	if agentName != "" {
 		attrs = append(attrs, attribute.String("langfuse.observation.metadata.agent_name", agentName))
+	}
+
+	// Add session ID from conversation context if available
+	if conversationID, ok := memory.GetConversationID(ctx); ok && conversationID != "" {
+		attrs = append(attrs, attribute.String("langfuse.session.id", conversationID))
 	}
 
 	// Start root OTEL span for the session

--- a/pkg/tracing/traced_llm.go
+++ b/pkg/tracing/traced_llm.go
@@ -23,6 +23,17 @@ func NewTracedLLM(llm interfaces.LLM, tracer interfaces.Tracer) interfaces.LLM {
 	}
 }
 
+// shouldIncludeContent checks if the tracer supports and has enabled content inclusion
+func (m *TracedLLM) shouldIncludeContent() bool {
+	if adapter, ok := m.tracer.(*OTELTracerAdapter); ok {
+		return adapter.otelTracer.ShouldIncludeContent()
+	}
+	if tracer, ok := m.tracer.(*OTELLangfuseTracer); ok {
+		return tracer.ShouldIncludeContent()
+	}
+	return false
+}
+
 // Generate generates text from a prompt with tracing
 func (m *TracedLLM) Generate(ctx context.Context, prompt string, options ...interfaces.GenerateOption) (string, error) {
 	startTime := time.Now()
@@ -56,6 +67,12 @@ func (m *TracedLLM) Generate(ctx context.Context, prompt string, options ...inte
 		span.SetAttribute("response.length", len(response))
 		span.SetAttribute("response.hash", hashString(response))
 		span.SetAttribute("duration_ms", duration.Milliseconds())
+
+		// Include actual content if configured
+		if m.shouldIncludeContent() {
+			span.SetAttribute("prompt.content", prompt)
+			span.SetAttribute("response.content", response)
+		}
 	} else {
 		span.RecordError(err)
 	}
@@ -113,6 +130,12 @@ func (m *TracedLLM) GenerateWithTools(ctx context.Context, prompt string, tools 
 			span.SetAttribute("response.length", len(response))
 			span.SetAttribute("response.hash", hashString(response))
 			span.SetAttribute("duration_ms", duration.Milliseconds())
+
+			// Include actual content if configured
+			if m.shouldIncludeContent() {
+				span.SetAttribute("prompt.content", prompt)
+				span.SetAttribute("response.content", response)
+			}
 		} else {
 			span.RecordError(err)
 		}
@@ -170,6 +193,11 @@ func (m *TracedLLM) GenerateStream(ctx context.Context, prompt string, options .
 	}
 	span.SetAttribute("model", model)
 
+	// Include actual prompt content if configured (response is streamed)
+	if m.shouldIncludeContent() {
+		span.SetAttribute("prompt.content", prompt)
+	}
+
 	return streamingLLM.GenerateStream(ctx, prompt, options...)
 }
 
@@ -208,6 +236,11 @@ func (m *TracedLLM) GenerateWithToolsStream(ctx context.Context, prompt string, 
 			toolNames[i] = tool.Name()
 		}
 		span.SetAttribute("tools", strings.Join(toolNames, ","))
+	}
+
+	// Include actual prompt content if configured (response is streamed)
+	if m.shouldIncludeContent() {
+		span.SetAttribute("prompt.content", prompt)
 	}
 
 	// Initialize tool calls collection in context for tracing
@@ -317,6 +350,12 @@ func (m *TracedLLM) GenerateDetailed(ctx context.Context, prompt string, options
 		}
 	}
 	span.SetAttribute("duration_ms", duration.Milliseconds())
+
+	// Include actual content if configured
+	if m.shouldIncludeContent() {
+		span.SetAttribute("prompt.content", prompt)
+		span.SetAttribute("response.content", response.Content)
+	}
 
 	return response, nil
 }


### PR DESCRIPTION
## Summary

- **Add `IncludeContent` option to LangfuseConfig** — when enabled (`LANGFUSE_INCLUDE_CONTENT=true`), logs actual prompts and responses as span attributes (`prompt.content`, `response.content`) alongside existing hashes. Defaults to `false` for privacy.
- **Add `langfuse.session.id` attribute** — automatically extracted from the conversation ID in context (`memory.GetConversationID`), enabling trace grouping by session in Langfuse.

## Changes

| File | Change |
|------|--------|
| `pkg/config/config.go` | Add `IncludeContent` field + `LANGFUSE_INCLUDE_CONTENT` env var |
| `pkg/tracing/langfuse.go` | Add `IncludeContent` to `LangfuseConfig` struct |
| `pkg/tracing/otel_langfuse.go` | Wire `IncludeContent`, add `ShouldIncludeContent()`, add `langfuse.session.id` to `StartSpan`, `TraceGeneration`, `StartTraceSession` |
| `pkg/tracing/traced_llm.go` | Add `shouldIncludeContent()` helper, conditionally emit `prompt.content`/`response.content` in all Generate* methods |

## Usage

```go
// Enable content tracing via config
tracer, _ := tracing.NewLangfuseTracer(tracing.LangfuseConfig{
    Enabled:        true,
    SecretKey:      "sk-...",
    PublicKey:      "pk-...",
    IncludeContent: true, // NEW: see actual prompts/responses in Langfuse
})

// Session ID is automatic — just set a conversation ID in context
ctx = memory.WithConversationID(ctx, "session-123")
// All subsequent traces will have langfuse.session.id = "session-123"
```

Or via environment variable:
```bash
export LANGFUSE_INCLUDE_CONTENT=true
```

## Test plan

- [ ] Verify `go vet ./pkg/tracing/... ./pkg/config/...` passes
- [ ] Verify traces in Langfuse show `prompt.content` and `response.content` when `IncludeContent=true`
- [ ] Verify traces show `langfuse.session.id` when conversation ID is set in context
- [ ] Verify backward compatibility — no change when `IncludeContent` is not set

Closes #221
Closes #208