### PR TITLE
feat: add WithDisableFinalSummary option to skip final LLM call

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -83,6 +83,7 @@ type Agent struct {
 	mcpServers           []interfaces.MCPServer   // MCP servers for the agent
 	lazyMCPConfigs       []LazyMCPConfig          // Lazy MCP server configurations
 	maxIterations        int                      // Maximum number of tool-calling iterations (default: 2)
+	disableFinalSummary  bool                     // When true, skip the final summary LLM call
 	streamConfig         *interfaces.StreamConfig // Streaming configuration for the agent
 	cacheConfig          *interfaces.CacheConfig  // Prompt caching configuration (Anthropic only)
 
@@ -251,6 +252,9 @@ func WithAgentConfig(config AgentConfig, variables map[string]string) Option {
 		// Apply behavioral settings
 		if expandedConfig.MaxIterations != nil {
 			a.maxIterations = *expandedConfig.MaxIterations
+		}
+		if expandedConfig.DisableFinalSummary != nil {
+			a.disableFinalSummary = *expandedConfig.DisableFinalSummary
 		}
 		if expandedConfig.RequirePlanApproval != nil {
 			a.requirePlanApproval = *expandedConfig.RequirePlanApproval
@@ -555,6 +559,13 @@ func WithMCPPresets(presetNames ...string) Option {
 func WithMaxIterations(maxIterations int) Option {
 	return func(a *Agent) {
 		a.maxIterations = maxIterations
+	}
+}
+
+// WithDisableFinalSummary sets whether to disable the final summary LLM call
+func WithDisableFinalSummary(disable bool) Option {
+	return func(a *Agent) {
+		a.disableFinalSummary = disable
 	}
 }
 
@@ -1248,6 +1259,7 @@ func (a *Agent) runWithoutExecutionPlanWithToolsTracked(ctx context.Context, inp
 	}
 
 	generateOptions = append(generateOptions, interfaces.WithMaxIterations(a.maxIterations))
+	generateOptions = append(generateOptions, interfaces.WithDisableFinalSummary(a.disableFinalSummary))
 
 	if a.memory != nil {
 		generateOptions = append(generateOptions, interfaces.WithMemory(a.memory))
@@ -2309,4 +2321,3 @@ func createImageStorageFromConfig(config *ImageStorageYAML) (storage.ImageStorag
 		return nil, fmt.Errorf("unsupported storage type: %s (only 'local' and 'gcs' are supported)", storageType)
 	}
 }
-

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -40,6 +40,7 @@ type AgentConfig struct {
 
 	// NEW: Behavioral settings
 	MaxIterations       *int  `yaml:"max_iterations,omitempty"`
+	DisableFinalSummary *bool `yaml:"disable_final_summary,omitempty"`
 	RequirePlanApproval *bool `yaml:"require_plan_approval,omitempty"`
 
 	// NEW: Complex configuration objects
@@ -141,27 +142,27 @@ type RuntimeConfigYAML struct {
 
 // ImageGenerationYAML represents image generation configuration in YAML
 type ImageGenerationYAML struct {
-	Enabled          *bool                      `yaml:"enabled,omitempty"`
-	Provider         string                     `yaml:"provider,omitempty"` // "gemini"
-	Model            string                     `yaml:"model,omitempty"`    // e.g., "gemini-2.5-flash-image"
-	Config           map[string]interface{}     `yaml:"config,omitempty"`
-	Storage          *ImageStorageYAML          `yaml:"storage,omitempty"`
-	MultiTurnEditing *MultiTurnEditingYAML      `yaml:"multi_turn_editing,omitempty"`
+	Enabled          *bool                  `yaml:"enabled,omitempty"`
+	Provider         string                 `yaml:"provider,omitempty"` // "gemini"
+	Model            string                 `yaml:"model,omitempty"`    // e.g., "gemini-2.5-flash-image"
+	Config           map[string]interface{} `yaml:"config,omitempty"`
+	Storage          *ImageStorageYAML      `yaml:"storage,omitempty"`
+	MultiTurnEditing *MultiTurnEditingYAML  `yaml:"multi_turn_editing,omitempty"`
 }
 
 // MultiTurnEditingYAML represents multi-turn image editing configuration in YAML
 type MultiTurnEditingYAML struct {
-	Enabled            *bool  `yaml:"enabled,omitempty"`
-	Model              string `yaml:"model,omitempty"`               // e.g., "gemini-3-pro-image-preview"
-	SessionTimeout     string `yaml:"session_timeout,omitempty"`     // e.g., "30m"
-	MaxSessionsPerOrg  *int   `yaml:"max_sessions_per_org,omitempty"`
+	Enabled           *bool  `yaml:"enabled,omitempty"`
+	Model             string `yaml:"model,omitempty"`           // e.g., "gemini-3-pro-image-preview"
+	SessionTimeout    string `yaml:"session_timeout,omitempty"` // e.g., "30m"
+	MaxSessionsPerOrg *int   `yaml:"max_sessions_per_org,omitempty"`
 }
 
 // ImageStorageYAML represents image storage configuration in YAML
 type ImageStorageYAML struct {
-	Type  string                 `yaml:"type,omitempty"` // "local", "gcs"
-	Local *LocalStorageYAML      `yaml:"local,omitempty"`
-	GCS   *GCSStorageYAML        `yaml:"gcs,omitempty"`
+	Type  string            `yaml:"type,omitempty"` // "local", "gcs"
+	Local *LocalStorageYAML `yaml:"local,omitempty"`
+	GCS   *GCSStorageYAML   `yaml:"gcs,omitempty"`
 }
 
 // LocalStorageYAML represents local storage configuration in YAML

--- a/pkg/interfaces/llm.go
+++ b/pkg/interfaces/llm.go
@@ -28,14 +28,15 @@ type GenerateOption func(options *GenerateOptions)
 
 // GenerateOptions contains configuration for text generation
 type GenerateOptions struct {
-	LLMConfig      *LLMConfig      // LLM config for the generation
-	OrgID          string          // For multi-tenancy
-	SystemMessage  string          // System message for chat models
-	ResponseFormat *ResponseFormat // Optional expected response format
-	MaxIterations  int             // Maximum number of tool-calling iterations (0 = use default)
-	Memory         Memory          // Optional memory for storing tool calls and results
-	StreamConfig   *StreamConfig   // Optional streaming configuration
-	CacheConfig    *CacheConfig    // Optional prompt caching configuration (Anthropic only)
+	LLMConfig           *LLMConfig      // LLM config for the generation
+	OrgID               string          // For multi-tenancy
+	SystemMessage       string          // System message for chat models
+	ResponseFormat      *ResponseFormat // Optional expected response format
+	MaxIterations       int             // Maximum number of tool-calling iterations (0 = use default)
+	DisableFinalSummary bool            // When true, skip the final "provide final response" LLM call
+	Memory              Memory          // Optional memory for storing tool calls and results
+	StreamConfig        *StreamConfig   // Optional streaming configuration
+	CacheConfig         *CacheConfig    // Optional prompt caching configuration (Anthropic only)
 }
 
 // CacheConfig contains configuration for prompt caching (Anthropic only)
@@ -68,6 +69,13 @@ type LLMConfig struct {
 func WithMaxIterations(maxIterations int) GenerateOption {
 	return func(options *GenerateOptions) {
 		options.MaxIterations = maxIterations
+	}
+}
+
+// WithDisableFinalSummary creates a GenerateOption to disable the final summary LLM call
+func WithDisableFinalSummary(disable bool) GenerateOption {
+	return func(options *GenerateOptions) {
+		options.DisableFinalSummary = disable
 	}
 }
 

--- a/pkg/llm/anthropic/client.go
+++ b/pkg/llm/anthropic/client.go
@@ -1080,6 +1080,9 @@ func (c *AnthropicClient) GenerateWithTools(ctx context.Context, prompt string, 
 		maxTokens = params.LLMConfig.ReasoningBudget + 4000 // Add buffer for actual response
 	}
 
+	// Track the last response content from the tool-calling loop
+	var lastContent string
+
 	// Iterative tool calling loop
 	for iteration := 0; iteration < maxIterations; iteration++ {
 		// Create request
@@ -1301,6 +1304,11 @@ func (c *AnthropicClient) GenerateWithTools(ctx context.Context, prompt string, 
 			"iteration":  iteration + 1,
 		})
 
+		// Capture the last text content from this iteration
+		if len(textContent) > 0 {
+			lastContent = strings.Join(textContent, "\n")
+		}
+
 		// If no tool use, return the text content
 		if !hasToolUse {
 			if len(textContent) == 0 {
@@ -1370,6 +1378,15 @@ func (c *AnthropicClient) GenerateWithTools(ctx context.Context, prompt string, 
 
 	// If we've reached the maximum iterations and the model is still requesting tools,
 	// make one final call without tools to get a conclusion
+
+	// If DisableFinalSummary is enabled, return the last response from the tool-calling loop
+	if params.DisableFinalSummary {
+		c.logger.Info(ctx, "DisableFinalSummary enabled, skipping final summary call", map[string]interface{}{
+			"maxIterations": maxIterations,
+		})
+		return lastContent, nil
+	}
+
 	c.logger.Info(ctx, "Maximum iterations reached, making final call without tools", map[string]interface{}{
 		"maxIterations": maxIterations,
 	})

--- a/pkg/llm/anthropic/streaming.go
+++ b/pkg/llm/anthropic/streaming.go
@@ -724,6 +724,14 @@ func (c *AnthropicClient) executeStreamingWithTools(
 	// After all tool iterations, make a final call without tools to get the synthesized answer
 	// This ensures the LLM provides a final response after processing all tool results
 
+	// If DisableFinalSummary is enabled, skip the final synthesis call
+	if params.DisableFinalSummary {
+		c.logger.Info(ctx, "DisableFinalSummary enabled, skipping final synthesis call", map[string]interface{}{
+			"maxIterations": maxIterations,
+		})
+		return nil
+	}
+
 	c.logger.Info(ctx, "[LLM RESPONSE DEBUG] Making final synthesis call after tool iterations", map[string]interface{}{
 		"maxIterations":         maxIterations,
 		"totalPreviousLLMCalls": finalIterationCount,

--- a/pkg/llm/azureopenai/client.go
+++ b/pkg/llm/azureopenai/client.go
@@ -637,6 +637,9 @@ func (c *AzureOpenAIClient) GenerateWithTools(ctx context.Context, prompt string
 	}
 
 	// Iterative tool calling loop
+	// Track the last response content from the tool-calling loop
+	var lastContent string
+
 	for iteration := 0; iteration < maxIterations; iteration++ {
 		// Update request with current messages
 		req.Messages = messages
@@ -678,11 +681,13 @@ func (c *AzureOpenAIClient) GenerateWithTools(ctx context.Context, prompt string
 			return "", fmt.Errorf("no completions returned")
 		}
 
+		// Capture the last content from the response
+		lastContent = strings.TrimSpace(resp.Choices[0].Message.Content)
+
 		// Check if the model wants to use tools
 		if len(resp.Choices[0].Message.ToolCalls) == 0 {
 			// No tool calls, return the response
-			content := strings.TrimSpace(resp.Choices[0].Message.Content)
-			return content, nil
+			return lastContent, nil
 		}
 
 		// The model wants to use tools
@@ -1024,6 +1029,15 @@ func (c *AzureOpenAIClient) GenerateWithTools(ctx context.Context, prompt string
 
 	// If we've reached the maximum iterations and the model is still requesting tools,
 	// make one final call without tools to get a conclusion
+
+	// If DisableFinalSummary is enabled, return the last response from the tool-calling loop
+	if params.DisableFinalSummary {
+		c.logger.Info(ctx, "DisableFinalSummary enabled, skipping final summary call", map[string]interface{}{
+			"maxIterations": maxIterations,
+		})
+		return lastContent, nil
+	}
+
 	c.logger.Info(ctx, "Maximum iterations reached, making final call without tools", map[string]interface{}{
 		"maxIterations": maxIterations,
 	})

--- a/pkg/llm/azureopenai/streaming.go
+++ b/pkg/llm/azureopenai/streaming.go
@@ -814,6 +814,18 @@ func (c *AzureOpenAIClient) GenerateWithToolsStream(
 			return
 		}
 
+		// If DisableFinalSummary is enabled, skip the final synthesis call
+		if params.DisableFinalSummary {
+			c.logger.Info(ctx, "DisableFinalSummary enabled, skipping final synthesis call", map[string]interface{}{
+				"maxIterations": maxIterations,
+			})
+			eventChan <- interfaces.StreamEvent{
+				Type:      interfaces.StreamEventMessageStop,
+				Timestamp: time.Now(),
+			}
+			return
+		}
+
 		// Final call without tools to get synthesis
 		c.logger.Info(ctx, "Maximum iterations reached, making final call without tools", map[string]interface{}{
 			"maxIterations": maxIterations,

--- a/pkg/llm/deepseek/streaming.go
+++ b/pkg/llm/deepseek/streaming.go
@@ -679,6 +679,18 @@ func (c *DeepSeekClient) GenerateWithToolsStream(
 			return
 		}
 
+		// If DisableFinalSummary is enabled, skip the final synthesis call
+		if params.DisableFinalSummary {
+			c.logger.Info(ctx, "DisableFinalSummary enabled, skipping final synthesis call", map[string]interface{}{
+				"maxIterations": maxIterations,
+			})
+			eventChan <- interfaces.StreamEvent{
+				Type:      interfaces.StreamEventMessageStop,
+				Timestamp: time.Now(),
+			}
+			return
+		}
+
 		// Final call without tools to get synthesis
 		c.logger.Info(ctx, "Maximum iterations reached, making final call without tools", map[string]interface{}{
 			"maxIterations": maxIterations,

--- a/pkg/llm/gemini/client.go
+++ b/pkg/llm/gemini/client.go
@@ -673,6 +673,9 @@ func (c *GeminiClient) GenerateWithTools(ctx context.Context, prompt string, too
 	}
 
 	// Iterative tool calling loop
+	// Track the last response content from the tool-calling loop
+	var lastContent string
+
 	for iteration := 0; iteration < maxIterations; iteration++ {
 		// Set generation config
 		var genConfig *genai.GenerationConfig
@@ -789,15 +792,20 @@ func (c *GeminiClient) GenerateWithTools(ctx context.Context, prompt string, too
 			}
 		}
 
+		// Extract text content from this iteration
+		var iterTextParts []string
+		for _, part := range candidate.Content.Parts {
+			if part.Text != "" {
+				iterTextParts = append(iterTextParts, part.Text)
+			}
+		}
+		if len(iterTextParts) > 0 {
+			lastContent = strings.Join(iterTextParts, " ")
+		}
+
 		// If no function calls, return the text response
 		if !hasFunctionCalls {
-			var textParts []string
-			for _, part := range candidate.Content.Parts {
-				if part.Text != "" {
-					textParts = append(textParts, part.Text)
-				}
-			}
-			return strings.Join(textParts, " "), nil
+			return lastContent, nil
 		}
 
 		// Process function calls
@@ -1023,6 +1031,15 @@ func (c *GeminiClient) GenerateWithTools(ctx context.Context, prompt string, too
 
 	// If we've reached the maximum iterations and the model is still requesting tools,
 	// make one final call without tools to get a conclusion
+
+	// If DisableFinalSummary is enabled, return the last response from the tool-calling loop
+	if params.DisableFinalSummary {
+		c.logger.Info(ctx, "DisableFinalSummary enabled, skipping final summary call", map[string]interface{}{
+			"maxIterations": maxIterations,
+		})
+		return lastContent, nil
+	}
+
 	c.logger.Info(ctx, "Maximum iterations reached, making final call without tools", map[string]interface{}{
 		"maxIterations": maxIterations,
 	})
@@ -1212,7 +1229,7 @@ func (c *GeminiClient) CreateImageEditSession(ctx context.Context, options *inte
 	}
 
 	c.logger.Debug(ctx, "Creating image edit session", map[string]interface{}{
-		"model":                model,
+		"model":                  model,
 		"has_system_instruction": options != nil && options.SystemInstruction != "",
 	})
 

--- a/pkg/llm/gemini/streaming.go
+++ b/pkg/llm/gemini/streaming.go
@@ -671,6 +671,15 @@ func (c *GeminiClient) generateWithToolsAndStream(ctx context.Context, prompt st
 
 	// After all tool iterations, make a final call without tools to get the synthesized answer
 	// This ensures the LLM provides a final response after processing all tool results
+
+	// If DisableFinalSummary is enabled, skip the final synthesis call
+	if params.DisableFinalSummary {
+		c.logger.Info(ctx, "DisableFinalSummary enabled, skipping final synthesis call", map[string]interface{}{
+			"maxIterations": maxIterations,
+		})
+		return "", nil
+	}
+
 	c.logger.Info(ctx, "Maximum iterations reached, making final call without tools", map[string]interface{}{
 		"maxIterations": maxIterations,
 	})

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -531,6 +531,9 @@ func (c *OpenAIClient) GenerateWithTools(ctx context.Context, prompt string, too
 		c.logger.Debug(ctx, "Using response format", map[string]interface{}{"format": *params.ResponseFormat})
 	}
 
+	// Track the last response content from the tool-calling loop
+	var lastContent string
+
 	// Iterative tool calling loop
 	for iteration := 0; iteration < maxIterations; iteration++ {
 		// Update request with current messages
@@ -569,11 +572,13 @@ func (c *OpenAIClient) GenerateWithTools(ctx context.Context, prompt string, too
 			return "", fmt.Errorf("no completions returned")
 		}
 
+		// Capture the last content from the response
+		lastContent = strings.TrimSpace(resp.Choices[0].Message.Content)
+
 		// Check if the model wants to use tools
 		if len(resp.Choices[0].Message.ToolCalls) == 0 {
 			// No tool calls, return the response
-			content := strings.TrimSpace(resp.Choices[0].Message.Content)
-			return content, nil
+			return lastContent, nil
 		}
 
 		// The model wants to use tools
@@ -916,6 +921,15 @@ func (c *OpenAIClient) GenerateWithTools(ctx context.Context, prompt string, too
 
 	// If we've reached the maximum iterations and the model is still requesting tools,
 	// make one final call without tools to get a conclusion
+
+	// If DisableFinalSummary is enabled, return the last response from the tool-calling loop
+	if params.DisableFinalSummary {
+		c.logger.Info(ctx, "DisableFinalSummary enabled, skipping final summary call", map[string]interface{}{
+			"maxIterations": maxIterations,
+		})
+		return lastContent, nil
+	}
+
 	c.logger.Info(ctx, "Maximum iterations reached, making final call without tools", map[string]interface{}{
 		"maxIterations": maxIterations,
 	})

--- a/pkg/llm/openai/streaming.go
+++ b/pkg/llm/openai/streaming.go
@@ -691,6 +691,18 @@ func (c *OpenAIClient) GenerateWithToolsStream(
 			return
 		}
 
+		// If DisableFinalSummary is enabled, skip the final synthesis call
+		if params.DisableFinalSummary {
+			c.logger.Info(ctx, "DisableFinalSummary enabled, skipping final synthesis call", map[string]interface{}{
+				"maxIterations": maxIterations,
+			})
+			eventChan <- interfaces.StreamEvent{
+				Type:      interfaces.StreamEventMessageStop,
+				Timestamp: time.Now(),
+			}
+			return
+		}
+
 		// Final call without tools to get synthesis
 		c.logger.Info(ctx, "Maximum iterations reached, making final call without tools", map[string]interface{}{
 			"maxIterations": maxIterations,


### PR DESCRIPTION
## Summary

Adds a `WithDisableFinalSummary(true)` agent option that skips the final "Please provide your final response..." LLM call after tool-calling iterations. This avoids:
- **Unnecessary API costs** — an extra LLM call on every agent run with tools
- **Response corruption** — the summary call often rephrases perfectly good tool-call responses

## Changes

| File | Change |
|------|--------|
| `pkg/interfaces/llm.go` | Add `DisableFinalSummary` to `GenerateOptions`, add `WithDisableFinalSummary` option |
| `pkg/agent/agent.go` | Add field, agent option, config wiring |
| `pkg/agent/config.go` | Add `disable_final_summary` YAML config |
| `pkg/llm/openai/client.go` | Skip final call, return last tool response |
| `pkg/llm/openai/streaming.go` | Skip final streaming synthesis |
| `pkg/llm/anthropic/client.go` | Skip final call, return last tool response |
| `pkg/llm/anthropic/streaming.go` | Skip final streaming synthesis |
| `pkg/llm/gemini/client.go` | Skip final call, return last tool response |
| `pkg/llm/gemini/streaming.go` | Skip final streaming synthesis |
| `pkg/llm/azureopenai/client.go` | Skip final call, return last tool response |
| `pkg/llm/azureopenai/streaming.go` | Skip final streaming synthesis |
| `pkg/llm/deepseek/streaming.go` | Skip final streaming synthesis |

## Usage

```go
myAgent, _ := agent.NewAgent(
    agent.WithLLM(llm),
    agent.WithMCPServers(mcpServers),
    agent.WithDisableFinalSummary(true), // Skip the extra LLM call
)

response, _ := myAgent.Run(ctx, "Query user ID 123")
// Returns the tool-calling response directly — no rephrasing
```

Or via YAML config:
```yaml
agent:
  role: "assistant"
  disable_final_summary: true
```

## Test plan

- [ ] Verify `go vet ./...` passes
- [ ] Agent with tools + `WithDisableFinalSummary(true)` returns the tool response directly
- [ ] Agent with tools + default (false) behavior is unchanged — still makes final summary call
- [ ] Streaming mode returns properly with `StreamEventMessageStop` when summary is disabled
- [ ] Non-tool agent runs are unaffected

Closes #230