### PR TITLE
Handling union of types in tool parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Ingenimax/agent-sdk-go
 
-go 1.24.4
+go 1.25.0
 
 require (
 	cloud.google.com/go/auth v0.18.0
@@ -16,7 +16,7 @@ require (
 	github.com/google/jsonschema-go v0.4.2
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
-	github.com/modelcontextprotocol/go-sdk v1.3.1
+	github.com/modelcontextprotocol/go-sdk v1.4.1
 	github.com/openai/openai-go v1.12.0
 	github.com/openai/openai-go/v2 v2.7.0
 	github.com/rs/zerolog v1.34.0
@@ -107,7 +107,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
-	github.com/segmentio/encoding v0.5.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGt
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
-github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -241,8 +241,8 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/modelcontextprotocol/go-sdk v1.3.1 h1:TfqtNKOIWN4Z1oqmPAiWDC2Jq7K9OdJaooe0teoXASI=
-github.com/modelcontextprotocol/go-sdk v1.3.1/go.mod h1:DgVX498dMD8UJlseK1S5i1T4tFz2fkBk4xogC3D15nw=
+github.com/modelcontextprotocol/go-sdk v1.4.1 h1:M4x9GyIPj+HoIlHNGpK2hq5o3BFhC+78PkEaldQRphc=
+github.com/modelcontextprotocol/go-sdk v1.4.1/go.mod h1:Bo/mS87hPQqHSRkMv4dQq1XCu6zv4INdXnFZabkNU6s=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
@@ -283,8 +283,8 @@ github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDc
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
-github.com/segmentio/encoding v0.5.3 h1:OjMgICtcSFuNvQCdwqMCv9Tg7lEOXGwm1J5RPQccx6w=
-github.com/segmentio/encoding v0.5.3/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -440,8 +440,8 @@ golang.org/x/tools v0.0.0-20190329151228-23e29df326fe/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190416151739-9c9e1878f421/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190420181800-aa740d480789/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/tools v0.39.0 h1:ik4ho21kwuQln40uelmciQPp9SipgNDdrafrYA4TmQQ=
-golang.org/x/tools v0.39.0/go.mod h1:JnefbkDPyD8UU2kI5fuf8ZX4/yUeh9W877ZeBONxUqQ=
+golang.org/x/tools v0.41.0 h1:a9b8iMweWG+S0OBnlU36rzLp20z1Rp10w+IY2czHTQc=
+golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=

--- a/pkg/interfaces/tool.go
+++ b/pkg/interfaces/tool.go
@@ -37,8 +37,8 @@ type InternalTool interface {
 
 // ParameterSpec defines the specification for a tool parameter
 type ParameterSpec struct {
-	// Type is the data type of the parameter (string, number, boolean, etc.)
-	Type string
+	// Type is the data type of the parameter (string, number, boolean, etc.) or union of types e.g. ["array", "null"]
+	Type any
 
 	// Description describes what the parameter is for
 	Description string

--- a/pkg/mcp/lazy.go
+++ b/pkg/mcp/lazy.go
@@ -548,10 +548,10 @@ func (t *LazyMCPTool) Parameters() map[string]interfaces.ParameterSpec {
 	if properties, ok := schemaMap["properties"].(map[string]interface{}); ok {
 		for name, prop := range properties {
 			if propMap, ok := prop.(map[string]interface{}); ok {
-				// Handle type extraction - support complex types like anyOf
-				var paramType string
+				// Handle type extraction - support complex types like anyOf and union types
+				var paramType any
 				if typeVal, ok := propMap["type"]; ok && typeVal != nil {
-					paramType = fmt.Sprintf("%v", typeVal)
+					paramType = typeVal
 				} else if anyOf, ok := propMap["anyOf"].([]interface{}); ok && len(anyOf) > 0 {
 					// For anyOf types, use the first non-null type
 					for _, typeOption := range anyOf {
@@ -562,7 +562,7 @@ func (t *LazyMCPTool) Parameters() map[string]interfaces.ParameterSpec {
 							}
 						}
 					}
-					if paramType == "" {
+					if paramType == nil {
 						paramType = "string" // fallback
 					}
 				} else {
@@ -574,8 +574,8 @@ func (t *LazyMCPTool) Parameters() map[string]interfaces.ParameterSpec {
 					Description: fmt.Sprintf("%v", propMap["description"]),
 				}
 
-				// Handle array items
-				if paramType == "array" {
+				// Handle array items when type is array or type is union that includes array
+				if paramType == "array" || strings.Contains(fmt.Sprintf("%v", paramType), "array") {
 					if items, ok := propMap["items"]; ok {
 						if itemsMap, ok := items.(map[string]interface{}); ok {
 							if itemType, ok := itemsMap["type"].(string); ok {

--- a/pkg/mcp/tool.go
+++ b/pkg/mcp/tool.go
@@ -101,7 +101,7 @@ func (t *MCPTool) Parameters() map[string]interfaces.ParameterSpec {
 			for name, prop := range properties {
 				if propMap, ok := prop.(map[string]interface{}); ok {
 					paramSpec := interfaces.ParameterSpec{
-						Type:        fmt.Sprintf("%v", propMap["type"]),
+						Type:        propMap["type"],
 						Description: fmt.Sprintf("%v", propMap["description"]),
 					}
 
@@ -122,7 +122,15 @@ func (t *MCPTool) Parameters() map[string]interfaces.ParameterSpec {
 	case *jsonschema.Schema:
 		for name, prop := range toolSchema.Properties {
 			paramSpec := interfaces.ParameterSpec{
-				Type:        prop.Type,
+				Type: func() any {
+					// Use Type if available, otherwise Types for complex types
+					if prop.Type != "" {
+						return prop.Type
+					} else if len(prop.Types) > 0 {
+						return prop.Types
+					}
+					return "string" // default to string if type is not specified
+				}(),
 				Description: prop.Description,
 			}
 


### PR DESCRIPTION
## Description
Currently, tool parameter schema conversion logic does not handle union types.
So, MCP server exposing following tool schema is not working with SDK.
`
{
  "additionalProperties": false,
  "properties": {
    "description": {
      "description": "description of the email receiver",
      "type": "string"
    },
    "email": {
      "description": "list of email addresses to be notified when an alert is triggered",
      "items": {
        "type": "string"
      },
      "type": [
        "null",
        "array"
      ]
    },
    "name": {
      "description": "name of the email receiver to be created and later used while creating an alert",
      "type": "string"
    }
  },
  "required": [
    "name",
    "email"
  ],
  "type": "object"
}
`

Fixes # (issue)

## Type of change

For both LazyMCPTool and MCPTool implementations, set type as ANY instead of string so that it can handle both primitive and union types. 

Also, MCP Golang SDK version is upgraded to fix vulnerabilities 


- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
After the change, I am able to call MCP Server tool with above JSON schema

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
