### PR TITLE
pkg/mcp: guard stderr buffer in NewStdioServerWithRetry against concurrent writes

### DIFF
--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -19,6 +20,28 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// syncBuffer is a bytes.Buffer guarded by a sync.Mutex. os/exec runs the
+// configured Stderr writer from a background goroutine, so reading from the
+// same bytes.Buffer in the parent while that goroutine is still writing is
+// a data race that the runtime flags under -race and can corrupt reads in
+// practice (issue #307).
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (sb *syncBuffer) Write(p []byte) (int, error) {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.buf.Write(p)
+}
+
+func (sb *syncBuffer) String() string {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.buf.String()
+}
 
 // MCPServerImpl is the implementation of interfaces.MCPServer using the official SDK
 type MCPServerImpl struct {
@@ -796,9 +819,11 @@ func NewStdioServerWithRetry(ctx context.Context, config StdioServerConfig, retr
 		}
 	}
 
-	// Capture stderr for debugging
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
+	// Capture stderr for debugging. Use a mutex-guarded buffer because
+	// os/exec writes stderr from a background goroutine while this code
+	// also reads via stderrBuf.String() below.
+	stderrBuf := &syncBuffer{}
+	cmd.Stderr = stderrBuf
 
 	// Create the command transport using the official SDK
 	transport := &mcp.CommandTransport{Command: cmd}


### PR DESCRIPTION
Fixes #307.

`NewStdioServerWithRetry` wired a plain `bytes.Buffer` up as `cmd.Stderr` and then read from that same buffer via `stderrBuf.String()` on the Connect-failure path and on the success log line. `os/exec` feeds the configured Stderr writer from a background goroutine that it spins up when the subprocess starts, so the parent's reads race the child's writes for the lifetime of the subprocess.

Running the package under `-race` trips the race detector reliably:

```
WARNING: DATA RACE
Read at 0x... by goroutine ...:
  bytes.(*Buffer).String()
      .../pkg/mcp/mcp.go:833
Previous write at 0x... by goroutine ...:
  bytes.(*Buffer).ReadFrom()
      os/exec.(*Cmd).writerDescriptor.func1
```

In practice the race can also produce torn reads of the stderr snapshot that the error log emits.

This PR introduces a small `syncBuffer` type — a `sync.Mutex`-guarded `bytes.Buffer` with the same `Write` / `String` surface — and uses it for the stderr sink. No other call sites change; the buffer is only ever written to by `os/exec` and read via `.String()` from this function.