### PR TITLE
llm/{openai,azureopenai}: drop the 40-char tool_call_id length guard that loses tool results

### DIFF
--- a/pkg/llm/azureopenai/streaming.go
+++ b/pkg/llm/azureopenai/streaming.go
@@ -715,14 +715,12 @@ func (c *AzureOpenAIClient) GenerateWithToolsStream(
 					"result_length": len(result),
 				})
 
-				// Ensure tool call ID is not swapped with result
-				if len(toolCall.ID) > 40 {
-					c.logger.Error(ctx, "Tool call ID too long", map[string]interface{}{
-						"id":        toolCall.ID,
-						"id_length": len(toolCall.ID),
-					})
-					continue
-				}
+				// Previous `len(toolCall.ID) > 40` guard dropped the tool
+				// result silently for any provider that emits IDs longer
+				// than 40 characters (vLLM's OpenAI-compatible API uses
+				// `chatcmpl-tool-{uuid}` which is 46 chars), leaving the
+				// agent stuck in an infinite tool-call loop (#299).
+				// OpenAI spec places no 40-char bound on tool_call_id.
 
 				// Add the tool call to the tracing context
 				fmt.Printf("DEBUG AzureOpenAI: Adding tool call %s to tracing context\n", toolCallTrace.Name)

--- a/pkg/llm/openai/streaming.go
+++ b/pkg/llm/openai/streaming.go
@@ -646,16 +646,15 @@ func (c *OpenAIClient) GenerateWithToolsStream(
 					"result_length": len(result),
 				})
 
-				// Ensure tool call ID is not swapped with result
-				if len(toolCall.ID) > 40 {
-					c.logger.Error(ctx, "Tool call ID too long", map[string]interface{}{
-						"id":        toolCall.ID,
-						"id_length": len(toolCall.ID),
-					})
-					continue
-				}
-
-				// Create tool message - correct parameter order: content first, then tool_call_id
+				// Create tool message - correct parameter order: content first, then tool_call_id.
+				// The previous `len(toolCall.ID) > 40` guard was a defensive check
+				// to catch an ID/result swap, but any provider that hands out IDs
+				// longer than 40 characters (vLLM's OpenAI-compatible API emits
+				// `chatcmpl-tool-{uuid}` at 46) silently dropped the tool result
+				// here, leaving the agent stuck in an infinite tool-call loop
+				// because the message history never reflected the tool output
+				// (#299). Let the upstream ToolMessage constructor accept the ID
+				// verbatim - OpenAI spec places no 40-char bound on tool_call_id.
 				toolMessage := openai.ToolMessage(result, toolCall.ID)
 				c.logger.Debug(ctx, "Created tool message", map[string]interface{}{
 					"message_type": "tool",


### PR DESCRIPTION
Fixes #299.

`GenerateWithToolsStream` appends every tool's output back into the message history so the model can synthesise a final answer. Both streaming clients gated that append on `len(toolCall.ID) > 40`:

```go
if len(toolCall.ID) > 40 {
    c.logger.Error(ctx, "Tool call ID too long", ...)
    continue
}
toolMessage := openai.ToolMessage(result, toolCall.ID)
messages = append(messages, toolMessage)
```

The 40-byte ceiling is not a protocol requirement. vLLM's OpenAI-compatible API emits IDs in the form `chatcmpl-tool-{uuid}` which are consistently 46 bytes, and every such tool result is now silently dropped. Because the conversation never reflects the tool output, the model asks for the same tool again on the next iteration and the agent enters an infinite tool-call loop on vLLM / any compliant provider with IDs longer than 40 chars.

This drops the guard from both `openai/streaming.go` and `azureopenai/streaming.go` and lets the upstream `ToolMessage` constructor receive the ID verbatim. OpenAI places no length bound on `tool_call_id`. No behaviour change for providers with shorter IDs; the previously-swallowed results are now appended as intended.