### PR TITLE
agent: don't re-collect MCP tools on every Run / streaming call

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -942,22 +942,17 @@ func (a *Agent) runLocalWithTracking(ctx context.Context, input string) (string,
 		return response, nil
 	}
 
-	// Use pre-initialized tools (manual + MCP tools already combined during agent creation)
+	// Use pre-initialized tools (manual + MCP tools already combined during
+	// agent creation). Re-collecting MCP tools into allTools here used to
+	// double every MCP tool on subsequent runs and Anthropic / other
+	// providers reject duplicate tool names with an invalid_request_error
+	// (#308). If an MCP server exposes new tools at runtime, re-run
+	// initializeMCPTools rather than silently duplicating here.
 	allTools := a.tools
-
-	if len(a.mcpServers) > 0 {
-		mcpTools, err := a.collectMCPTools(ctx)
-		if err != nil {
-			// Log warning but continue - MCP tools are optional
-			a.logger.Warn(context.Background(), fmt.Sprintf("Failed to collect MCP tools: %v", err), nil)
-		} else if len(mcpTools) > 0 {
-			allTools = append(allTools, mcpTools...)
-		}
-	}
 
 	if len(a.lazyMCPConfigs) > 0 {
 		lazyMCPTools := a.createLazyMCPTools()
-		allTools = append(allTools, lazyMCPTools...)
+		allTools = deduplicateTools(append(allTools, lazyMCPTools...))
 	}
 
 	if (len(allTools) > 0) && a.requirePlanApproval {

--- a/pkg/agent/streaming.go
+++ b/pkg/agent/streaming.go
@@ -206,20 +206,12 @@ func (a *Agent) runLocalStream(ctx context.Context, input string) (<-chan interf
 			return
 		}
 
-		// Collect all tools
+		// Collect all tools. a.tools is already the deduplicated union of
+		// manual tools and MCP-server tools (see initializeMCPTools);
+		// re-collecting from a.mcpServers here used to duplicate every MCP
+		// tool per run and Anthropic / other providers reject duplicate
+		// tool names (#308).
 		allTools := a.tools
-
-		// Add MCP tools if available
-		if len(a.mcpServers) > 0 {
-			mcpTools, err := a.collectMCPTools(ctx)
-			if err != nil {
-				// Log the error but continue with the agent tools
-				// Warning: Failed to collect MCP tools
-				fmt.Printf("Warning: Failed to collect MCP tools: %v\n", err)
-			} else if len(mcpTools) > 0 {
-				allTools = append(allTools, mcpTools...)
-			}
-		}
 
 		// If tools are available and plan approval is required, we can't stream execution plans yet
 		if (len(allTools) > 0) && a.requirePlanApproval {


### PR DESCRIPTION
## Summary

`initializeMCPTools` (called at agent construction) already merges manual tools with MCP-server tools and runs `deduplicateTools` on the result. `Run` and the streaming path in `pkg/agent/streaming.go` then:

```go
allTools := a.tools
if len(a.mcpServers) > 0 {
    mcpTools, _ := a.collectMCPTools(ctx)
    allTools = append(allTools, mcpTools...) // no dedup
}
```

So every subsequent call re-fetched the same MCP tools and handed the LLM two copies of every tool. Anthropic (and other providers) reject duplicate tool names with `invalid_request_error: tools: Tool names must be unique` — exactly what #308 reports.

Fixes #308.

## Change

- `pkg/agent/agent.go`: drop the redundant MCP re-collection in `Run`. Keep the lazy MCP block but run `deduplicateTools` on the append so dynamic tools don't double either.
- `pkg/agent/streaming.go`: same change on the streaming path.
- A short comment at both sites explains why we rely on `a.tools` directly.

If a server exposes new tools after construction, callers should re-run `initializeMCPTools` rather than rely on a silent duplication side-channel.

## Testing

- `go test ./pkg/agent/...` passes.
- Manually ran an Anthropic-backed agent configured with an MCP server: a first request and a second request now produce identical tool counts; prior to this fix the second request tripled up a few tools and Anthropic returned `400 invalid_request_error`.
