### PR TITLE
structuredoutput: skip fields tagged json:"-" when building the schema

### DIFF
--- a/pkg/structuredoutput/utils.go
+++ b/pkg/structuredoutput/utils.go
@@ -32,6 +32,12 @@ func getJSONSchema(t reflect.Type) map[string]any {
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		jsonTag := strings.Split(field.Tag.Get("json"), ",")[0]
+		if jsonTag == "-" {
+			// Field is explicitly excluded from JSON; skip it so it
+			// doesn't surface in the generated schema as a "-" property
+			// (#300).
+			continue
+		}
 		if jsonTag == "" {
 			jsonTag = field.Name
 		}
@@ -138,6 +144,10 @@ func getRequiredFields(t reflect.Type) []string {
 		field := t.Field(i)
 		if !strings.Contains(field.Tag.Get("json"), "omitempty") {
 			jsonTag := strings.Split(field.Tag.Get("json"), ",")[0]
+			if jsonTag == "-" {
+				// Excluded from JSON entirely; must not be required.
+				continue
+			}
 			if jsonTag == "" {
 				jsonTag = field.Name
 			}


### PR DESCRIPTION
## Summary

`getJSONSchema` and `getRequiredFields` in `pkg/structuredoutput/utils.go` read the first segment of the struct field's `json` tag and never special-case `"-"`. A field declared as

```go
type Resp struct {
    Internal string `json:"-"`
    Public   string `json:"public"`
}
```

currently produces:

- `properties` with a `"-"` key describing `Internal`.
- `required` containing `"-"` (unless the field is `omitempty`).

Downstream, the LLM is then forced to emit a key literally named `"-"` to satisfy the schema.

This PR matches `encoding/json`'s convention: if the first tag segment is `"-"`, skip the field from both the property map and the required list.

Fixes #300.

## Testing

- `go test ./pkg/structuredoutput/...` passes.
- Added a local regression: `NewResponseFormat(Resp{}).Schema.properties` no longer contains a `"-"` key, and `required` contains only `"public"`.
