### PR TITLE
agent/streaming: guard every eventChan send against context cancel

### DIFF
--- a/pkg/agent/streaming.go
+++ b/pkg/agent/streaming.go
@@ -13,6 +13,21 @@ import (
 	"github.com/Ingenimax/agent-sdk-go/pkg/tracing"
 )
 
+// sendEvent pushes an AgentStreamEvent onto eventChan while respecting
+// caller cancellation. Every blocking send on eventChan in this file goes
+// through this helper so that abandoning the returned channel (timeout,
+// client disconnect, etc.) doesn't leak the producing goroutine waiting
+// on an unread channel (#291). Returns true on success, false if ctx was
+// cancelled before the event could be delivered.
+func sendEvent(ctx context.Context, eventChan chan<- interfaces.AgentStreamEvent, event interfaces.AgentStreamEvent) bool {
+	select {
+	case eventChan <- event:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 // RunStream executes the agent with streaming response
 func (a *Agent) RunStream(ctx context.Context, input string) (<-chan interfaces.AgentStreamEvent, error) {
 	// If custom stream function is set, use it instead
@@ -130,11 +145,11 @@ func (a *Agent) runLocalStream(ctx context.Context, input string) (<-chan interf
 				Role:    "user",
 				Content: input,
 			}); err != nil {
-				eventChan <- interfaces.AgentStreamEvent{
+				sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 					Type:      interfaces.AgentEventError,
 					Error:     fmt.Errorf("failed to add user message to memory: %w", err),
 					Timestamp: time.Now(),
-				}
+				})
 				return
 			}
 		}
@@ -144,11 +159,11 @@ func (a *Agent) runLocalStream(ctx context.Context, input string) (<-chan interf
 		if a.guardrails != nil {
 			guardedInput, err := a.guardrails.ProcessInput(ctx, input)
 			if err != nil {
-				eventChan <- interfaces.AgentStreamEvent{
+				sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 					Type:      interfaces.AgentEventError,
 					Error:     fmt.Errorf("guardrails error: %w", err),
 					Timestamp: time.Now(),
-				}
+				})
 				return
 			}
 			processedInput = guardedInput
@@ -160,17 +175,17 @@ func (a *Agent) runLocalStream(ctx context.Context, input string) (<-chan interf
 			// For now, plan actions are not streamed - fall back to regular handling
 			result, err := a.handlePlanAction(ctx, taskID, action, planInput)
 			if err != nil {
-				eventChan <- interfaces.AgentStreamEvent{
+				sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 					Type:      interfaces.AgentEventError,
 					Error:     err,
 					Timestamp: time.Now(),
-				}
+				})
 			} else {
-				eventChan <- interfaces.AgentStreamEvent{
+				sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 					Type:      interfaces.AgentEventContent,
 					Content:   result,
 					Timestamp: time.Now(),
-				}
+				})
 			}
 			return
 		}
@@ -185,24 +200,24 @@ func (a *Agent) runLocalStream(ctx context.Context, input string) (<-chan interf
 					Role:    "assistant",
 					Content: response,
 				}); err != nil {
-					eventChan <- interfaces.AgentStreamEvent{
+					sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 						Type:      interfaces.AgentEventError,
 						Error:     fmt.Errorf("failed to add role response to memory: %w", err),
 						Timestamp: time.Now(),
-					}
+					})
 					return
 				}
 			}
 
-			eventChan <- interfaces.AgentStreamEvent{
+			sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 				Type:      interfaces.AgentEventContent,
 				Content:   response,
 				Timestamp: time.Now(),
-			}
-			eventChan <- interfaces.AgentStreamEvent{
+			})
+			sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 				Type:      interfaces.AgentEventComplete,
 				Timestamp: time.Now(),
-			}
+			})
 			return
 		}
 
@@ -226,21 +241,21 @@ func (a *Agent) runLocalStream(ctx context.Context, input string) (<-chan interf
 			// For now, fall back to non-streaming execution plan generation
 			result, err := a.runWithExecutionPlan(ctx, processedInput)
 			if err != nil {
-				eventChan <- interfaces.AgentStreamEvent{
+				sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 					Type:      interfaces.AgentEventError,
 					Error:     err,
 					Timestamp: time.Now(),
-				}
+				})
 			} else {
-				eventChan <- interfaces.AgentStreamEvent{
+				sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 					Type:      interfaces.AgentEventContent,
 					Content:   result,
 					Timestamp: time.Now(),
-				}
-				eventChan <- interfaces.AgentStreamEvent{
+				})
+				sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 					Type:      interfaces.AgentEventComplete,
 					Timestamp: time.Now(),
-				}
+				})
 			}
 			return
 		}
@@ -249,11 +264,11 @@ func (a *Agent) runLocalStream(ctx context.Context, input string) (<-chan interf
 		length, err := a.runStreamingGeneration(ctx, processedInput, allTools, streamingLLM, eventChan)
 		responseLength = length
 		if err != nil {
-			eventChan <- interfaces.AgentStreamEvent{
+			sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 				Type:      interfaces.AgentEventError,
 				Error:     err,
 				Timestamp: time.Now(),
-			}
+			})
 		}
 	}()
 
@@ -376,7 +391,9 @@ func (a *Agent) runStreamingGeneration(
 		}
 
 		// Send agent event
-		eventChan <- agentEvent
+		if !sendEvent(ctx, eventChan, agentEvent) {
+			return int64(accumulatedContent.Len()), finalError
+		}
 	}
 
 	// Add messages to memory if available (save even on error to preserve conversation history)
@@ -422,14 +439,14 @@ func (a *Agent) runStreamingGeneration(
 	}
 
 	// Send completion event
-	eventChan <- interfaces.AgentStreamEvent{
+	sendEvent(ctx, eventChan, interfaces.AgentStreamEvent{
 		Type:      interfaces.AgentEventComplete,
 		Timestamp: time.Now(),
 		Metadata: map[string]interface{}{
 			"total_content_length": accumulatedContent.Len(),
 			"had_error":            finalError != nil,
 		},
-	}
+	})
 
 	return int64(accumulatedContent.Len()), finalError
 }


### PR DESCRIPTION
## Summary

`runLocalStream` and `runStreamingGeneration` in `pkg/agent/streaming.go` issue blocking sends on `eventChan` from a goroutine spawned by `RunStream`. If the caller stops reading (client timeout, UI navigation, cancelled context) before the stream finishes, the producer blocks forever on an unread channel, leaking goroutines plus the full agent execution context they hold references to.

`streamForwarder` in the same file already uses the right pattern:

```go
select {
case eventChan <- event:
case <-ctx.Done():
    return
}
```

Fixes #291.

## Change

- Add a `sendEvent(ctx, eventChan, event) bool` helper at the top of the file that implements exactly the select pattern above.
- Route every bare `eventChan <-` call site in this file through the helper: memory-error sends, guardrails-error sends, the plan-action path, the role-identity shortcut, the plan-approval fallback, the main per-chunk forwarding loop, the trailing error send, and the final `AgentEventComplete`.
- In the main forwarding loop, return early when `sendEvent` reports the caller is gone so we don't keep synthesising agent events against a dead channel.

## Testing

- `go test ./pkg/agent/...` passes.
- Added a local goroutine-count regression: starting 20 `RunStream` calls and abandoning each after one event and a context cancel now brings `runtime.NumGoroutine()` back to baseline within a second; before this change each abandoned stream left a stuck producer behind.
