### PR TITLE
openai/streaming: drop 40-char tool_call_id guard that breaks vLLM

### DIFF
--- a/pkg/llm/openai/streaming.go
+++ b/pkg/llm/openai/streaming.go
@@ -646,16 +646,11 @@ func (c *OpenAIClient) GenerateWithToolsStream(
 					"result_length": len(result),
 				})
 
-				// Ensure tool call ID is not swapped with result
-				if len(toolCall.ID) > 40 {
-					c.logger.Error(ctx, "Tool call ID too long", map[string]interface{}{
-						"id":        toolCall.ID,
-						"id_length": len(toolCall.ID),
-					})
-					continue
-				}
-
-				// Create tool message - correct parameter order: content first, then tool_call_id
+				// Create tool message - correct parameter order: content first, then tool_call_id.
+				// Any id length the upstream server emits is valid here (OpenAI-compatible
+				// backends such as vLLM use `chatcmpl-tool-<uuid>` which is 46 chars and
+				// legitimately exceeded the old 40-char guard, dropping every tool_result
+				// and looping the agent on the same call (#299)).
 				toolMessage := openai.ToolMessage(result, toolCall.ID)
 				c.logger.Debug(ctx, "Created tool message", map[string]interface{}{
 					"message_type": "tool",


### PR DESCRIPTION
## Summary

Fixes #299.

`GenerateWithToolsStream` in `pkg/llm/openai/streaming.go` dropped every `tool_result` whose `tool_call_id` exceeded 40 characters, on the theory that an overlong id meant the result had been swapped in by mistake. In practice, OpenAI-compatible backends routinely emit longer ids - vLLM's `chatcmpl-tool-<uuid>` is consistently 46 characters - so every `tool_result` was thrown away, the model never saw the tool output, and the agent looped forever on the same call.

## Fix

Delete the 40-char guard and `continue` branch. OpenAI's own `tool_call_id` limit is 256 characters; letting the upstream server's id through is correct. The existing defensive debug log a few lines above still records `tool_call_id` and `id_length` so genuinely malformed ids stay observable without silently breaking conversation history.

## Test plan

- [x] `go build ./pkg/llm/openai/`
- [x] `go vet ./pkg/llm/openai/`
- [x] `go test ./pkg/llm/openai/ -count=1` passes
- [x] Manually constructed a tool_call_id of 46 chars (`chatcmpl-tool-8174c6dc1d3047b3953aa8f422063ddb`) and confirmed the `toolMessage` is now appended to `messages` and the model sees the result on the next iteration
