### PR TITLE
Fix Gemini tool declarations dropping array items end-to-end (#318)

### DIFF
--- a/pkg/llm/gemini/client.go
+++ b/pkg/llm/gemini/client.go
@@ -556,85 +556,9 @@ func (c *GeminiClient) GenerateWithTools(ctx context.Context, prompt string, too
 	}
 	_ = orgID // Mark as used to avoid linter warning
 
-	// Convert tools to Gemini format
-	geminiTools := make([]*genai.FunctionDeclaration, 0, len(tools))
-	for _, tool := range tools {
-		functionDeclaration := &genai.FunctionDeclaration{
-			Name:        tool.Name(),
-			Description: tool.Description(),
-			Parameters: &genai.Schema{
-				Type:       genai.TypeObject,
-				Properties: make(map[string]*genai.Schema),
-				Required:   make([]string, 0),
-			},
-		}
-
-		// Convert parameters
-		for name, param := range tool.Parameters() {
-			paramSchema := &genai.Schema{
-				Description: param.Description,
-			}
-
-			// Set type
-			switch param.Type {
-			case "string":
-				paramSchema.Type = genai.TypeString
-			case "number", "integer":
-				paramSchema.Type = genai.TypeNumber
-			case "boolean":
-				paramSchema.Type = genai.TypeBoolean
-			case "array":
-				paramSchema.Type = genai.TypeArray
-			case "object":
-				paramSchema.Type = genai.TypeObject
-			}
-
-			// Handle array items
-			if param.Items != nil {
-				itemSchema := &genai.Schema{}
-
-				// Set items type
-				switch param.Items.Type {
-				case "string":
-					itemSchema.Type = genai.TypeString
-				case "number", "integer":
-					itemSchema.Type = genai.TypeNumber
-				case "boolean":
-					itemSchema.Type = genai.TypeBoolean
-				case "array":
-					itemSchema.Type = genai.TypeArray
-				case "object":
-					itemSchema.Type = genai.TypeObject
-				}
-
-				// Handle items enum if present
-				if param.Items.Enum != nil {
-					enumStrings := make([]string, len(param.Items.Enum))
-					for i, e := range param.Items.Enum {
-						enumStrings[i] = fmt.Sprintf("%v", e)
-					}
-					itemSchema.Enum = enumStrings
-				}
-
-				paramSchema.Items = itemSchema
-			}
-
-			if param.Enum != nil {
-				enumStrings := make([]string, len(param.Enum))
-				for i, e := range param.Enum {
-					enumStrings[i] = fmt.Sprintf("%v", e)
-				}
-				paramSchema.Enum = enumStrings
-			}
-
-			functionDeclaration.Parameters.Properties[name] = paramSchema
-			if param.Required {
-				functionDeclaration.Parameters.Required = append(functionDeclaration.Parameters.Required, name)
-			}
-		}
-
-		geminiTools = append(geminiTools, functionDeclaration)
-	}
+	// Convert tools to Gemini format. Shared with GenerateStreamWithTools so
+	// Ask and Stream agree on schema shape, including array `items`.
+	geminiTools := convertToolsToFunctionDeclarations(tools)
 
 	// Build contents with memory and current prompt
 	contents := c.buildContentsWithMemory(ctx, prompt, params)

--- a/pkg/llm/gemini/streaming.go
+++ b/pkg/llm/gemini/streaming.go
@@ -392,60 +392,12 @@ func (c *GeminiClient) generateWithToolsAndStream(ctx context.Context, prompt st
 		c.logger.Debug(ctx, "Using system message for tool streaming", map[string]interface{}{"system_message": params.SystemMessage})
 	}
 
-	// Convert tools to Gemini format - all function declarations in a single tool
-	var functionDeclarations []*genai.FunctionDeclaration
-	for _, tool := range tools {
-		functionDeclaration := &genai.FunctionDeclaration{
-			Name:        tool.Name(),
-			Description: tool.Description(),
-			Parameters: &genai.Schema{
-				Type:       genai.TypeObject,
-				Properties: make(map[string]*genai.Schema),
-				Required:   make([]string, 0),
-			},
-		}
-
-		// Convert parameters
-		for name, param := range tool.Parameters() {
-			paramSchema := &genai.Schema{
-				Description: param.Description,
-			}
-
-			// Set type
-			switch param.Type {
-			case "string":
-				paramSchema.Type = genai.TypeString
-			case "number", "integer":
-				paramSchema.Type = genai.TypeNumber
-			case "boolean":
-				paramSchema.Type = genai.TypeBoolean
-			case "array":
-				paramSchema.Type = genai.TypeArray
-			case "object":
-				paramSchema.Type = genai.TypeObject
-			}
-
-			if param.Enum != nil {
-				enumStrings := make([]string, len(param.Enum))
-				for i, e := range param.Enum {
-					enumStrings[i] = fmt.Sprintf("%v", e)
-				}
-				paramSchema.Enum = enumStrings
-			}
-
-			functionDeclaration.Parameters.Properties[name] = paramSchema
-			if param.Required {
-				functionDeclaration.Parameters.Required = append(functionDeclaration.Parameters.Required, name)
-			}
-		}
-
-		functionDeclarations = append(functionDeclarations, functionDeclaration)
-	}
-
-	// Create a single tool with all function declarations
+	// Convert tools to Gemini format - all function declarations in a single tool.
+	// Shared with the non-streaming path so array `items` and other schema
+	// details stay consistent between Ask and Stream.
 	geminiTools := []*genai.Tool{
 		{
-			FunctionDeclarations: functionDeclarations,
+			FunctionDeclarations: convertToolsToFunctionDeclarations(tools),
 		},
 	}
 

--- a/pkg/llm/gemini/tools.go
+++ b/pkg/llm/gemini/tools.go
@@ -1,0 +1,115 @@
+package gemini
+
+import (
+	"fmt"
+
+	"google.golang.org/genai"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// convertToolsToFunctionDeclarations turns interfaces.Tool definitions into
+// Gemini function declarations. It is shared by the non-streaming
+// GenerateWithTools path (client.go) and the streaming GenerateStream /
+// GenerateStreamWithTools path (streaming.go) so both agree on schema
+// details like array items.
+func convertToolsToFunctionDeclarations(tools []interfaces.Tool) []*genai.FunctionDeclaration {
+	declarations := make([]*genai.FunctionDeclaration, 0, len(tools))
+	for _, tool := range tools {
+		declaration := &genai.FunctionDeclaration{
+			Name:        tool.Name(),
+			Description: tool.Description(),
+			Parameters: &genai.Schema{
+				Type:       genai.TypeObject,
+				Properties: make(map[string]*genai.Schema),
+				Required:   make([]string, 0),
+			},
+		}
+
+		for name, param := range tool.Parameters() {
+			paramSchema := &genai.Schema{
+				Description: param.Description,
+			}
+			paramSchema.Type = geminiTypeOf(param.Type)
+
+			// Gemini requires `items` on any `array` parameter; the
+			// server-supplied schema may omit it, so default to string
+			// items when we don't have better information.
+			if paramSchema.Type == genai.TypeArray {
+				paramSchema.Items = convertItemsToSchema(param.Items)
+			}
+
+			if param.Enum != nil {
+				enumStrings := make([]string, len(param.Enum))
+				for i, e := range param.Enum {
+					enumStrings[i] = fmt.Sprintf("%v", e)
+				}
+				paramSchema.Enum = enumStrings
+			}
+
+			declaration.Parameters.Properties[name] = paramSchema
+			if param.Required {
+				declaration.Parameters.Required = append(declaration.Parameters.Required, name)
+			}
+		}
+
+		declarations = append(declarations, declaration)
+	}
+	return declarations
+}
+
+// convertItemsToSchema produces a genai.Schema for an array's `items`.
+// Never returns nil when called, because Gemini rejects array schemas
+// missing `items`.
+func convertItemsToSchema(items *interfaces.ParameterSpec) *genai.Schema {
+	if items == nil {
+		return &genai.Schema{Type: genai.TypeString}
+	}
+	itemSchema := &genai.Schema{Type: geminiTypeOf(items.Type)}
+	if itemSchema.Type == "" {
+		itemSchema.Type = genai.TypeString
+	}
+	if items.Enum != nil {
+		enumStrings := make([]string, len(items.Enum))
+		for i, e := range items.Enum {
+			enumStrings[i] = fmt.Sprintf("%v", e)
+		}
+		itemSchema.Enum = enumStrings
+	}
+	return itemSchema
+}
+
+// geminiTypeOf maps a ParameterSpec.Type (which may be a string or a
+// []string union) to a genai.Type. Returns empty string when unknown so
+// callers can decide on a default.
+func geminiTypeOf(t interface{}) genai.Type {
+	switch v := t.(type) {
+	case string:
+		switch v {
+		case "string":
+			return genai.TypeString
+		case "number", "integer":
+			return genai.TypeNumber
+		case "boolean":
+			return genai.TypeBoolean
+		case "array":
+			return genai.TypeArray
+		case "object":
+			return genai.TypeObject
+		}
+	case []string:
+		for _, s := range v {
+			if s == "null" {
+				continue
+			}
+			return geminiTypeOf(s)
+		}
+	case []interface{}:
+		for _, s := range v {
+			if str, ok := s.(string); ok && str != "null" {
+				return geminiTypeOf(str)
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/llm/gemini/tools_test.go
+++ b/pkg/llm/gemini/tools_test.go
@@ -1,0 +1,120 @@
+package gemini
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/genai"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// fakeTool is a minimal interfaces.Tool for exercising
+// convertToolsToFunctionDeclarations without the rest of the SDK.
+type fakeTool struct {
+	name   string
+	params map[string]interfaces.ParameterSpec
+}
+
+func (t *fakeTool) Name() string                                    { return t.name }
+func (t *fakeTool) Description() string                             { return "" }
+func (t *fakeTool) Parameters() map[string]interfaces.ParameterSpec { return t.params }
+func (t *fakeTool) Execute(context.Context, string) (string, error) { return "", nil }
+func (t *fakeTool) Run(context.Context, string) (string, error)     { return "", nil }
+
+// TestConvertTools_PropagatesArrayItems is a regression test for the bug
+// where the streaming path dropped ParameterSpec.Items, causing Gemini to
+// reject any MCP tool that exposed an "array" parameter with
+// INVALID_ARGUMENT "properties[...].items: missing field".
+func TestConvertTools_PropagatesArrayItems(t *testing.T) {
+	tool := &fakeTool{
+		name: "publish",
+		params: map[string]interfaces.ParameterSpec{
+			"labels": {
+				Type: "array",
+				Items: &interfaces.ParameterSpec{
+					Type: "string",
+					Enum: []interface{}{"bug", "feature"},
+				},
+				Required: true,
+			},
+			"priority": {
+				Type: "string",
+				Enum: []interface{}{"low", "high"},
+			},
+		},
+	}
+
+	decls := convertToolsToFunctionDeclarations([]interfaces.Tool{tool})
+	if len(decls) != 1 {
+		t.Fatalf("want 1 declaration, got %d", len(decls))
+	}
+	props := decls[0].Parameters.Properties
+	labels := props["labels"]
+	if labels == nil || labels.Type != genai.TypeArray {
+		t.Fatalf("labels missing or wrong type: %+v", labels)
+	}
+	if labels.Items == nil || labels.Items.Type != genai.TypeString {
+		t.Fatalf("labels.items dropped: %+v", labels.Items)
+	}
+	if len(labels.Items.Enum) != 2 {
+		t.Fatalf("labels.items.enum dropped: %v", labels.Items.Enum)
+	}
+	if len(decls[0].Parameters.Required) != 1 || decls[0].Parameters.Required[0] != "labels" {
+		t.Fatalf("required list wrong: %v", decls[0].Parameters.Required)
+	}
+
+	priority := props["priority"]
+	if len(priority.Enum) != 2 {
+		t.Fatalf("priority enum dropped: %v", priority.Enum)
+	}
+}
+
+// TestConvertTools_ArrayWithoutItems_DefaultsToString covers MCP servers
+// that advertise an `array` without `items` (common in the GitHub MCP
+// server). Gemini requires items, so we default to string items instead
+// of emitting an invalid schema.
+func TestConvertTools_ArrayWithoutItems_DefaultsToString(t *testing.T) {
+	tool := &fakeTool{
+		name: "noisy",
+		params: map[string]interfaces.ParameterSpec{
+			"files": {Type: "array"},
+		},
+	}
+	decls := convertToolsToFunctionDeclarations([]interfaces.Tool{tool})
+	files := decls[0].Parameters.Properties["files"]
+	if files.Items == nil || files.Items.Type != genai.TypeString {
+		t.Fatalf("expected default string items, got %+v", files.Items)
+	}
+}
+
+// TestConvertTools_UnionTypes covers anyOf-style types represented as
+// []string or []interface{} unions (e.g. ["array","null"]). The helper
+// should pick the first non-null branch.
+func TestConvertTools_UnionTypes(t *testing.T) {
+	tool := &fakeTool{
+		name: "union",
+		params: map[string]interfaces.ParameterSpec{
+			"maybeList": {
+				Type: []string{"array", "null"},
+				Items: &interfaces.ParameterSpec{
+					Type: "string",
+				},
+			},
+			"maybeName": {
+				Type: []interface{}{"null", "string"},
+			},
+		},
+	}
+	decls := convertToolsToFunctionDeclarations([]interfaces.Tool{tool})
+	props := decls[0].Parameters.Properties
+	if props["maybeList"].Type != genai.TypeArray {
+		t.Fatalf("maybeList type not resolved: %v", props["maybeList"].Type)
+	}
+	if props["maybeList"].Items == nil || props["maybeList"].Items.Type != genai.TypeString {
+		t.Fatalf("maybeList.items dropped: %+v", props["maybeList"].Items)
+	}
+	if props["maybeName"].Type != genai.TypeString {
+		t.Fatalf("maybeName type not resolved: %v", props["maybeName"].Type)
+	}
+}

--- a/pkg/mcp/lazy.go
+++ b/pkg/mcp/lazy.go
@@ -574,21 +574,18 @@ func (t *LazyMCPTool) Parameters() map[string]interfaces.ParameterSpec {
 					Description: fmt.Sprintf("%v", propMap["description"]),
 				}
 
-				// Handle array items when type is array or type is union that includes array
+				// Handle array items when type is array or type is union that includes array.
+				// Gemini and OpenAI reject function declarations that expose an `array`
+				// without `items`, so default to string items when the server's schema
+				// omits, malforms, or nests `items.type`.
 				if paramType == "array" || strings.Contains(fmt.Sprintf("%v", paramType), "array") {
-					if items, ok := propMap["items"]; ok {
-						if itemsMap, ok := items.(map[string]interface{}); ok {
-							if itemType, ok := itemsMap["type"].(string); ok {
-								paramSpec.Items = &interfaces.ParameterSpec{
-									Type: itemType,
-								}
-								// Handle enum for items if present
-								if enum, ok := itemsMap["enum"]; ok {
-									if enumSlice, ok := enum.([]interface{}); ok {
-										paramSpec.Items.Enum = enumSlice
-									}
-								}
-							}
+					paramSpec.Items = &interfaces.ParameterSpec{Type: "string"}
+					if itemsMap, ok := propMap["items"].(map[string]interface{}); ok {
+						if itemType, ok := itemsMap["type"].(string); ok && itemType != "" {
+							paramSpec.Items.Type = itemType
+						}
+						if enum, ok := itemsMap["enum"].([]interface{}); ok {
+							paramSpec.Items.Enum = enum
 						}
 					}
 				}

--- a/pkg/mcp/tool.go
+++ b/pkg/mcp/tool.go
@@ -105,6 +105,19 @@ func (t *MCPTool) Parameters() map[string]interfaces.ParameterSpec {
 						Description: fmt.Sprintf("%v", propMap["description"]),
 					}
 
+					// Array parameters must carry an items specification;
+					// downstream converters (Gemini, OpenAI) reject
+					// function declarations that expose an `array` without
+					// `items`. Default to string items when the server's
+					// schema omits or malforms it.
+					if typeStr := asString(propMap["type"]); typeStr == "array" {
+						paramSpec.Items = extractItemsFromMap(propMap["items"])
+					}
+
+					if enum, ok := propMap["enum"].([]interface{}); ok {
+						paramSpec.Enum = enum
+					}
+
 					// Check if the parameter is required
 					if required, ok := toolSchema["required"].([]interface{}); ok {
 						for _, req := range required {
@@ -134,6 +147,14 @@ func (t *MCPTool) Parameters() map[string]interfaces.ParameterSpec {
 				Description: prop.Description,
 			}
 
+			if prop.Type == "array" {
+				paramSpec.Items = extractItemsFromSchema(prop.Items)
+			}
+
+			if len(prop.Enum) > 0 {
+				paramSpec.Enum = append(paramSpec.Enum, prop.Enum...)
+			}
+
 			if slices.Contains(toolSchema.Required, name) {
 				paramSpec.Required = true
 			}
@@ -141,6 +162,54 @@ func (t *MCPTool) Parameters() map[string]interfaces.ParameterSpec {
 		}
 	}
 	return params
+}
+
+// asString returns v as a string if it is one, empty string otherwise. Used
+// to inspect JSON Schema "type" fields, which may be a plain string or a
+// union like []string{"array","null"}; union handling is left to
+// LazyMCPTool.Parameters which has more context.
+func asString(v interface{}) string {
+	s, _ := v.(string)
+	return s
+}
+
+// extractItemsFromMap derives a ParameterSpec for an array's items from the
+// raw JSON Schema fragment at `items`. Falls back to {Type:"string"} when
+// the fragment is missing or malformed so Gemini/OpenAI accept the
+// resulting function declaration.
+func extractItemsFromMap(raw interface{}) *interfaces.ParameterSpec {
+	defaultSpec := &interfaces.ParameterSpec{Type: "string"}
+	itemsMap, ok := raw.(map[string]interface{})
+	if !ok {
+		return defaultSpec
+	}
+	itemType, _ := itemsMap["type"].(string)
+	if itemType == "" {
+		itemType = "string"
+	}
+	spec := &interfaces.ParameterSpec{Type: itemType}
+	if enum, ok := itemsMap["enum"].([]interface{}); ok {
+		spec.Enum = enum
+	}
+	return spec
+}
+
+// extractItemsFromSchema is the *jsonschema.Schema analogue of
+// extractItemsFromMap.
+func extractItemsFromSchema(items *jsonschema.Schema) *interfaces.ParameterSpec {
+	defaultSpec := &interfaces.ParameterSpec{Type: "string"}
+	if items == nil {
+		return defaultSpec
+	}
+	itemType := items.Type
+	if itemType == "" {
+		itemType = "string"
+	}
+	spec := &interfaces.ParameterSpec{Type: itemType}
+	if len(items.Enum) > 0 {
+		spec.Enum = append(spec.Enum, items.Enum...)
+	}
+	return spec
 }
 
 // Execute executes the tool with the given arguments

--- a/pkg/mcp/tool_test.go
+++ b/pkg/mcp/tool_test.go
@@ -1,0 +1,119 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+// TestMCPToolParameters_ArrayItems_MapSchema verifies that an array
+// parameter sourced from a raw map schema carries its `items` through to
+// the ParameterSpec. Gemini (and strict OpenAI) reject tools where an
+// `array` parameter is missing `items`.
+func TestMCPToolParameters_ArrayItems_MapSchema(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"tags": map[string]interface{}{
+				"type":        "array",
+				"description": "list of tags",
+				"items": map[string]interface{}{
+					"type": "string",
+					"enum": []interface{}{"a", "b"},
+				},
+			},
+			"mode": map[string]interface{}{
+				"type": "string",
+				"enum": []interface{}{"fast", "slow"},
+			},
+		},
+		"required": []interface{}{"tags"},
+	}
+
+	tool := NewMCPTool("t", "d", schema, nil)
+	params := tool.Parameters()
+
+	tags, ok := params["tags"]
+	if !ok {
+		t.Fatalf("missing tags param")
+	}
+	if !tags.Required {
+		t.Fatalf("tags should be required")
+	}
+	if tags.Items == nil {
+		t.Fatalf("array param dropped Items")
+	}
+	if tags.Items.Type != "string" {
+		t.Fatalf("unexpected items type: %v", tags.Items.Type)
+	}
+	if len(tags.Items.Enum) != 2 {
+		t.Fatalf("items enum lost: %v", tags.Items.Enum)
+	}
+
+	mode := params["mode"]
+	if len(mode.Enum) != 2 {
+		t.Fatalf("top-level enum lost: %v", mode.Enum)
+	}
+}
+
+// TestMCPToolParameters_ArrayMissingItems_DefaultsToString mirrors the
+// real-world case (e.g. the GitHub MCP server's "files" field) where the
+// server advertises `type:array` without an `items` entry. Emitting such a
+// tool to Gemini used to fail with INVALID_ARGUMENT
+// "properties[...].items: missing field".
+func TestMCPToolParameters_ArrayMissingItems_DefaultsToString(t *testing.T) {
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"files": map[string]interface{}{
+				"type":        "array",
+				"description": "files to commit",
+			},
+		},
+	}
+	tool := NewMCPTool("t", "d", schema, nil)
+	params := tool.Parameters()
+	if params["files"].Items == nil || params["files"].Items.Type != "string" {
+		t.Fatalf("expected default string items, got %+v", params["files"].Items)
+	}
+}
+
+// TestMCPToolParameters_ArrayItems_JSONSchema covers the *jsonschema.Schema
+// branch of Parameters; previously it dropped both Items and Enum.
+func TestMCPToolParameters_ArrayItems_JSONSchema(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"labels": {
+				Type: "array",
+				Items: &jsonschema.Schema{
+					Type: "string",
+					Enum: []any{"bug", "feature"},
+				},
+			},
+		},
+		Required: []string{"labels"},
+	}
+
+	tool := NewMCPTool("t", "d", schema, nil)
+	params := tool.Parameters()
+
+	labels, ok := params["labels"]
+	if !ok {
+		t.Fatalf("missing labels param")
+	}
+	if !labels.Required {
+		t.Fatalf("labels should be required")
+	}
+	if labels.Items == nil || labels.Items.Type != "string" {
+		t.Fatalf("items dropped or wrong type: %+v", labels.Items)
+	}
+	if len(labels.Items.Enum) != 2 {
+		t.Fatalf("items enum lost: %v", labels.Items.Enum)
+	}
+}
+
+// Ensure ParameterSpec.Items was actually exposed by the interface we
+// depend on; this guards against silent renames upstream.
+var _ = interfaces.ParameterSpec{Items: &interfaces.ParameterSpec{}}


### PR DESCRIPTION
## Summary

Closes #318.

Any MCP tool whose JSON Schema exposes an `array` parameter (GitHub labels / assignees / reviewers, GCP gcloud args, k8s manifest lists, AWS EC2 tag specs, …) was rejected by Gemini with:

```
INVALID_ARGUMENT: GenerateContentRequest.tools[0].function_declarations[N]
.parameters.properties[labels].items: missing field.
```

Two independent layers each dropped `items`, which is why neither streaming nor non-streaming worked reliably:

1. **`pkg/mcp/tool.go` / `pkg/mcp/lazy.go`** — `MCPTool.Parameters()` and `LazyMCPTool.Parameters()` translated raw MCP schemas into `ParameterSpec` without ever reading `items`. The `*jsonschema.Schema` branch in `tool.go` dropped both `Items` and `Enum`. `lazy.go` only handled `items` when `items.type` was a simple string; anything else silently became a bare `array`.

2. **`pkg/llm/gemini/streaming.go`** — `convertTool` never read `ParameterSpec.Items` at all, so even when layer (1) produced the right spec the array schema emitted to Gemini was missing `items`. The non-streaming path in `client.go` had the correct `param.Items` block — it just never received populated specs from layer (1) for MCP tools.

## Changes

### `pkg/mcp/tool.go`
- `MCPTool.Parameters()` now reads `items` + `enum` in both the `map[string]interface{}` and `*jsonschema.Schema` branches.
- Arrays without an `items` declaration (common with loosely-typed MCP servers, e.g. GitHub's `files` field) default to `{Type:"string"}` rather than being emitted bare — Gemini rejects the latter.
- New private helpers `asString`, `extractItemsFromMap`, `extractItemsFromSchema` keep the two branches consistent.

### `pkg/mcp/lazy.go`
- Same default-to-string fallback for arrays with missing / malformed / non-string `items.type`.
- Preserves existing enum / nested-type handling.

### `pkg/llm/gemini/tools.go` (new)
- Shared `convertToolsToFunctionDeclarations` used by both streaming and non-streaming Gemini paths. This is the mechanical dedup that ensures schema-shape stays in sync forever.
- Helpers `convertItemsToSchema` (never returns nil — Gemini requires `items` on every array) and `geminiTypeOf` (maps `ParameterSpec.Type` including `[]string` / `[]interface{}` unions to `genai.Type`, picking the first non-null branch).

### `pkg/llm/gemini/client.go`, `pkg/llm/gemini/streaming.go`
- Replace the duplicated hand-rolled tool-conversion loops with a single call to the shared helper.

## Tests

New test files exercise the fix without requiring a live Gemini:

- **`pkg/mcp/tool_test.go`**
  - `TestMCPToolParameters_ArrayItems_MapSchema` — array `items` (including nested `enum`) and top-level enum propagate from a raw `map[string]interface{}` schema.
  - `TestMCPToolParameters_ArrayMissingItems_DefaultsToString` — regression test for the GitHub MCP `files` field: `type:array` with no `items` gets `{Type:"string"}` so Gemini accepts it.
  - `TestMCPToolParameters_ArrayItems_JSONSchema` — same coverage for the `*jsonschema.Schema` branch that previously silently dropped `Items` and `Enum`.
- **`pkg/llm/gemini/tools_test.go`**
  - `TestConvertTools_PropagatesArrayItems` — end-to-end items + enum through `convertToolsToFunctionDeclarations` (the direct regression test for the streaming `items: missing field` failure).
  - `TestConvertTools_ArrayWithoutItems_DefaultsToString` — default-string fallback at the Gemini layer.
  - `TestConvertTools_UnionTypes` — anyOf-style `[]string{"array","null"}` / `[]interface{}{"null","string"}` unions resolve to the first non-null branch.

`go vet ./...` is clean and `go test ./...` passes across the module.

## Test plan

- [x] `go vet ./...` clean against the patched SDK
- [x] `go test ./...` passes (all packages)
- [x] Unit tests in `pkg/mcp/tool_test.go` and `pkg/llm/gemini/tools_test.go` fail on `main` and pass on this branch
- [x] **Downstream end-to-end validation**: wired this fork in via a `go.mod` `replace` in a downstream project that exercises MCP servers for AWS / NativeK8s / EKS / GKE / GitHub / Azure / GCP. With this branch:
  - Non-streaming (`Ask`) path works across all 7 providers — no more `properties[...].items: missing field`.
  - Streaming (`RunStream`) path works across all 7 providers — Gemini emits `tool_use` events with array arguments and the MCP servers receive them. This is the path the existing issue called out as having no in-tree workaround.
  - Downstream code that was wrapping every MCP tool with a custom `geminiSchemaMCPTool` to patch around this bug has been removed locally and everything still works.

## Compatibility

- `MCPTool.Parameters()` / `LazyMCPTool.Parameters()` return more information than before (previously they silently lost `Items` / `Enum` for arrays). Callers that were inspecting `ParameterSpec.Items == nil` for arrays may now see non-nil — this matches the original JSON Schema and what every LLM provider expects.
- No public API additions or removals; no signature changes.
- `convertToolsToFunctionDeclarations`, `convertItemsToSchema`, `geminiTypeOf` are unexported.
