### PR TITLE
fix(agent): deduplicate MCP tools before sending to LLM

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -942,7 +942,10 @@ func (a *Agent) runLocalWithTracking(ctx context.Context, input string) (string,
 		return response, nil
 	}
 
-	// Use pre-initialized tools (manual + MCP tools already combined during agent creation)
+	// Use pre-initialized tools (manual + MCP tools already combined during agent creation).
+	// initializeMCPTools already populated a.tools, so re-collecting here can append duplicates;
+	// always run the merged slice through deduplicateTools to defend against that and against
+	// MCP servers re-listing tools they already exposed at startup.
 	allTools := a.tools
 
 	if len(a.mcpServers) > 0 {
@@ -951,13 +954,13 @@ func (a *Agent) runLocalWithTracking(ctx context.Context, input string) (string,
 			// Log warning but continue - MCP tools are optional
 			a.logger.Warn(context.Background(), fmt.Sprintf("Failed to collect MCP tools: %v", err), nil)
 		} else if len(mcpTools) > 0 {
-			allTools = append(allTools, mcpTools...)
+			allTools = deduplicateTools(append(allTools, mcpTools...))
 		}
 	}
 
 	if len(a.lazyMCPConfigs) > 0 {
 		lazyMCPTools := a.createLazyMCPTools()
-		allTools = append(allTools, lazyMCPTools...)
+		allTools = deduplicateTools(append(allTools, lazyMCPTools...))
 	}
 
 	if (len(allTools) > 0) && a.requirePlanApproval {

--- a/pkg/agent/streaming.go
+++ b/pkg/agent/streaming.go
@@ -206,7 +206,10 @@ func (a *Agent) runLocalStream(ctx context.Context, input string) (<-chan interf
 			return
 		}
 
-		// Collect all tools
+		// Collect all tools. initializeMCPTools already populated a.tools, so the
+		// runtime re-collect below can re-add the same tools; deduplicate after the
+		// append to keep tool names unique (LLM providers like Anthropic reject
+		// requests with duplicate tool names — see issue #308).
 		allTools := a.tools
 
 		// Add MCP tools if available
@@ -217,7 +220,7 @@ func (a *Agent) runLocalStream(ctx context.Context, input string) (<-chan interf
 				// Warning: Failed to collect MCP tools
 				fmt.Printf("Warning: Failed to collect MCP tools: %v\n", err)
 			} else if len(mcpTools) > 0 {
-				allTools = append(allTools, mcpTools...)
+				allTools = deduplicateTools(append(allTools, mcpTools...))
 			}
 		}
 


### PR DESCRIPTION
## Summary

Closes #308.

When `mcpServers` is configured, `initializeMCPTools` already populates `a.tools` with the server's tools at agent creation, but `Run` / `RunStream` re-call `collectMCPTools` on every invocation and `append` the result to `a.tools` without deduplicating. Each MCP tool ends up listed twice in the request payload, and providers like Anthropic reject the call:

```
invalid_request_error: tools: Tool names must be unique.
```

## Fix

Wrap the runtime `append`s with the existing `deduplicateTools` helper. This affects:

* `agent.Run` (`pkg/agent/agent.go`) — both the `mcpServers` path and the `lazyMCPConfigs` path
* the streaming path (`pkg/agent/streaming.go`)

The fix is minimal and uses the helper that's already used by `WithTools` and `initializeMCPTools`, so duplicate names cannot leak through regardless of whether the duplication comes from the eager-init / runtime-collect overlap (the case in the issue) or from an MCP server re-listing a tool it already exposed.

## Test plan

- [x] `go build ./pkg/agent/...`
- [x] `go test -count=1 -short ./pkg/agent/` — all passing