### PR TITLE
fix(openai): skip default top_p=0 in generate requests

### DIFF
--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -176,7 +176,7 @@ func (c *OpenAIClient) generateInternal(ctx context.Context, prompt string, opti
 	if params.LLMConfig != nil {
 		req.Temperature = openai.Float(c.getTemperatureForModel(params.LLMConfig.Temperature))
 		// Reasoning models don't support top_p parameter
-		if !isReasoningModel(c.Model) {
+		if !isReasoningModel(c.Model) && params.LLMConfig.TopP > 0 && params.LLMConfig.TopP <= 1 {
 			req.TopP = openai.Float(params.LLMConfig.TopP)
 		}
 		req.FrequencyPenalty = openai.Float(params.LLMConfig.FrequencyPenalty)
@@ -495,7 +495,7 @@ func (c *OpenAIClient) GenerateWithTools(ctx context.Context, prompt string, too
 	}
 
 	// Reasoning models don't support top_p parameter
-	if !isReasoningModel(c.Model) {
+	if !isReasoningModel(c.Model) && params.LLMConfig.TopP > 0 && params.LLMConfig.TopP <= 1 {
 		req.TopP = openai.Float(params.LLMConfig.TopP)
 	}
 
@@ -945,7 +945,7 @@ func (c *OpenAIClient) GenerateWithTools(ctx context.Context, prompt string, too
 	}
 
 	// Reasoning models don't support top_p parameter
-	if !isReasoningModel(c.Model) {
+	if !isReasoningModel(c.Model) && params.LLMConfig.TopP > 0 && params.LLMConfig.TopP <= 1 {
 		finalReq.TopP = openai.Float(params.LLMConfig.TopP)
 	}
 

--- a/pkg/llm/openai/client_test.go
+++ b/pkg/llm/openai/client_test.go
@@ -82,6 +82,72 @@ func TestGenerate(t *testing.T) {
 	}
 }
 
+func TestGenerate_OmitsZeroTopPByDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+
+		if _, ok := reqBody["top_p"]; ok {
+			t.Fatalf("expected top_p to be omitted when no GenerateOptions are provided")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(openai.ChatCompletion{Choices: []openai.ChatCompletionChoice{{Message: openai.ChatCompletionMessage{Content: "ok", Role: "assistant"}}}})
+	}))
+	defer server.Close()
+
+	logger := logging.New()
+	client := openai_client.NewClient("test-key",
+		openai_client.WithModel("gpt-4"),
+		openai_client.WithLogger(logger),
+	)
+	client.ChatService = openai.NewChatService(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL(server.URL),
+	)
+
+	if _, err := client.Generate(context.Background(), "who are you"); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+}
+
+func TestGenerate_IncludesTopPWhenExplicitlySet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+
+		v, ok := reqBody["top_p"].(float64)
+		if !ok {
+			t.Fatalf("expected top_p in request when explicitly set")
+		}
+		if v != 0.9 {
+			t.Fatalf("expected top_p=0.9, got %v", v)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(openai.ChatCompletion{Choices: []openai.ChatCompletionChoice{{Message: openai.ChatCompletionMessage{Content: "ok", Role: "assistant"}}}})
+	}))
+	defer server.Close()
+
+	logger := logging.New()
+	client := openai_client.NewClient("test-key",
+		openai_client.WithModel("gpt-4"),
+		openai_client.WithLogger(logger),
+	)
+	client.ChatService = openai.NewChatService(
+		option.WithAPIKey("test-key"),
+		option.WithBaseURL(server.URL),
+	)
+
+	if _, err := client.Generate(context.Background(), "who are you", openai_client.WithTopP(0.9)); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+}
+
 func TestChat(t *testing.T) {
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Replaces #306 (rebase against current main; original branch had unresolvable conflicts after dependency updates landed via #303 and #309).

Original author: @saschabuehrle (commit attribution preserved via cherry-pick).

## Summary

Fixes #282. When `Generate()` is called without explicit options, `TopP` stayed at its zero value and was serialized as `top_p: 0`, which strict OpenAI-compatible backends reject.

This PR only sets `top_p` when it is within the valid `(0, 1]` range in generate request paths (including tool and final-summary calls).

Adds regression tests:
- `top_p` is omitted by default
- `top_p` is still sent when explicitly set (e.g. `WithTopP(0.9)`)