### PR TITLE
fix(agent): record tool calls on actual invocation, not availability

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1274,21 +1274,19 @@ func (a *Agent) runWithoutExecutionPlanWithToolsTracked(ctx context.Context, inp
 	tracker := getUsageTracker(ctx)
 
 	if len(tools) > 0 {
-		if tracker != nil {
-			for _, tool := range tools {
-				tracker.addToolCall(tool.Name())
-			}
-		}
+		// Record tool invocations as the LLM actually calls them, not the
+		// full set of available tools (#305).
+		toolsForLLM := wrapToolsWithTracker(tools, tracker)
 
 		if tracker != nil && tracker.detailed {
-			llmResp, err := a.llm.GenerateWithToolsDetailed(ctx, prompt, tools, generateOptions...)
+			llmResp, err := a.llm.GenerateWithToolsDetailed(ctx, prompt, toolsForLLM, generateOptions...)
 			if err != nil {
 				return "", fmt.Errorf("failed to generate response: %w", err)
 			}
 			response = llmResp.Content
 			tracker.addLLMUsage(llmResp.Usage, llmResp.Model)
 		} else {
-			response, err = a.llm.GenerateWithTools(ctx, prompt, tools, generateOptions...)
+			response, err = a.llm.GenerateWithTools(ctx, prompt, toolsForLLM, generateOptions...)
 			if err != nil {
 				return "", fmt.Errorf("failed to generate response: %w", err)
 			}

--- a/pkg/agent/agent_detailed_test.go
+++ b/pkg/agent/agent_detailed_test.go
@@ -11,6 +11,10 @@ import (
 type MockLLMForDetailed struct {
 	responses []string
 	callCount int
+	// invokeOnly, when non-nil, restricts which tools the mock invokes during
+	// GenerateWithToolsDetailed. nil means invoke every provided tool. Use the
+	// non-nil empty slice to skip all tools.
+	invokeOnly []string
 }
 
 func (m *MockLLMForDetailed) Generate(ctx context.Context, prompt string, options ...interfaces.GenerateOption) (string, error) {
@@ -48,12 +52,27 @@ func (m *MockLLMForDetailed) GenerateDetailed(ctx context.Context, prompt string
 }
 
 func (m *MockLLMForDetailed) GenerateWithToolsDetailed(ctx context.Context, prompt string, tools []interfaces.Tool, options ...interfaces.GenerateOption) (*interfaces.LLMResponse, error) {
-	// Simulate the LLM choosing to invoke each provided tool so the agent's
-	// per-invocation usage tracker observes a real call.
+	// Simulate the LLM choosing to invoke a subset of provided tools so the
+	// agent's per-invocation usage tracker observes a real call. By default
+	// we invoke every tool; if invokeOnly is set, we invoke only the named
+	// subset (still in the order they appear in tools, so tests can assert
+	// ordering when they care).
 	for _, t := range tools {
+		if m.invokeOnly != nil && !containsString(m.invokeOnly, t.Name()) {
+			continue
+		}
 		_, _ = t.Execute(ctx, "{}")
 	}
 	return m.GenerateDetailed(ctx, prompt, options...)
+}
+
+func containsString(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *MockLLMForDetailed) Name() string {
@@ -166,6 +185,37 @@ func TestAgentRunDetailedWithTools(t *testing.T) {
 	assert.Equal(t, 100, response.Usage.InputTokens)
 	assert.Equal(t, 50, response.Usage.OutputTokens)
 	assert.Equal(t, 150, response.Usage.TotalTokens)
+}
+
+// TestAgentRunDetailedRecordsOnlyInvokedTools is the regression test for #305:
+// when the agent has multiple tools available but the LLM only invokes a
+// subset, the execution summary must reflect just the invoked tools rather
+// than every tool that was offered.
+func TestAgentRunDetailedRecordsOnlyInvokedTools(t *testing.T) {
+	mockLLM := &MockLLMForDetailed{
+		responses:  []string{"Used one of the two tools"},
+		invokeOnly: []string{"called_tool"},
+	}
+
+	calledTool := &MockTool{name: "called_tool", description: "Tool the LLM invokes"}
+	skippedTool := &MockTool{name: "skipped_tool", description: "Tool the LLM ignores"}
+
+	agent, err := NewAgent(
+		WithLLM(mockLLM),
+		WithName("partial-tool-agent"),
+		WithTools(calledTool, skippedTool),
+		WithRequirePlanApproval(false),
+	)
+	assert.NoError(t, err)
+
+	response, err := agent.RunDetailed(context.Background(), "Use what you need")
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+
+	assert.Equal(t, 1, response.ExecutionSummary.ToolCalls,
+		"only the invoked tool should be counted")
+	assert.Equal(t, []string{"called_tool"}, response.ExecutionSummary.UsedTools,
+		"skipped_tool must not appear in UsedTools")
 }
 
 func TestUsageTrackerAggregation(t *testing.T) {

--- a/pkg/agent/agent_detailed_test.go
+++ b/pkg/agent/agent_detailed_test.go
@@ -48,6 +48,11 @@ func (m *MockLLMForDetailed) GenerateDetailed(ctx context.Context, prompt string
 }
 
 func (m *MockLLMForDetailed) GenerateWithToolsDetailed(ctx context.Context, prompt string, tools []interfaces.Tool, options ...interfaces.GenerateOption) (*interfaces.LLMResponse, error) {
+	// Simulate the LLM choosing to invoke each provided tool so the agent's
+	// per-invocation usage tracker observes a real call.
+	for _, t := range tools {
+		_, _ = t.Execute(ctx, "{}")
+	}
 	return m.GenerateDetailed(ctx, prompt, options...)
 }
 

--- a/pkg/agent/streaming.go
+++ b/pkg/agent/streaming.go
@@ -349,7 +349,10 @@ func (a *Agent) runStreamingGeneration(
 	var err error
 
 	if len(allTools) > 0 {
-		llmEventChan, err = streamingLLM.GenerateWithToolsStream(ctxWithForwarder, input, allTools, options...)
+		// Record tool invocations as the LLM actually calls them, not the
+		// full set of available tools (#305).
+		toolsForLLM := wrapToolsWithTracker(allTools, getUsageTracker(ctx))
+		llmEventChan, err = streamingLLM.GenerateWithToolsStream(ctxWithForwarder, input, toolsForLLM, options...)
 	} else {
 		llmEventChan, err = streamingLLM.GenerateStream(ctxWithForwarder, input, options...)
 	}

--- a/pkg/agent/tracking_tool.go
+++ b/pkg/agent/tracking_tool.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// trackingTool wraps a Tool and records each invocation with the usage tracker
+// before delegating. Records the call when the LLM client actually invokes
+// Execute or Run, so the execution summary reflects tools the model chose to
+// call rather than every tool that was made available.
+type trackingTool struct {
+	inner   interfaces.Tool
+	tracker *usageTracker
+}
+
+func (t *trackingTool) Name() string                                  { return t.inner.Name() }
+func (t *trackingTool) Description() string                           { return t.inner.Description() }
+func (t *trackingTool) Parameters() map[string]interfaces.ParameterSpec { return t.inner.Parameters() }
+
+func (t *trackingTool) Run(ctx context.Context, input string) (string, error) {
+	t.tracker.addToolCall(t.inner.Name())
+	return t.inner.Run(ctx, input)
+}
+
+func (t *trackingTool) Execute(ctx context.Context, args string) (string, error) {
+	t.tracker.addToolCall(t.inner.Name())
+	return t.inner.Execute(ctx, args)
+}
+
+// DisplayName forwards to the inner tool when it implements ToolWithDisplayName.
+func (t *trackingTool) DisplayName() string {
+	if d, ok := t.inner.(interfaces.ToolWithDisplayName); ok {
+		return d.DisplayName()
+	}
+	return t.inner.Name()
+}
+
+// Internal forwards to the inner tool when it implements InternalTool.
+func (t *trackingTool) Internal() bool {
+	if i, ok := t.inner.(interfaces.InternalTool); ok {
+		return i.Internal()
+	}
+	return false
+}
+
+// wrapToolsWithTracker wraps each tool so its invocation is recorded with the
+// tracker. Returns the original slice unchanged when tracker is nil.
+func wrapToolsWithTracker(tools []interfaces.Tool, tracker *usageTracker) []interfaces.Tool {
+	if tracker == nil || len(tools) == 0 {
+		return tools
+	}
+	wrapped := make([]interfaces.Tool, len(tools))
+	for i, t := range tools {
+		wrapped[i] = &trackingTool{inner: t, tracker: tracker}
+	}
+	return wrapped
+}

--- a/pkg/agent/tracking_tool.go
+++ b/pkg/agent/tracking_tool.go
@@ -20,12 +20,16 @@ func (t *trackingTool) Description() string                           { return t
 func (t *trackingTool) Parameters() map[string]interfaces.ParameterSpec { return t.inner.Parameters() }
 
 func (t *trackingTool) Run(ctx context.Context, input string) (string, error) {
-	t.tracker.addToolCall(t.inner.Name())
+	if t.tracker != nil {
+		t.tracker.addToolCall(t.inner.Name())
+	}
 	return t.inner.Run(ctx, input)
 }
 
 func (t *trackingTool) Execute(ctx context.Context, args string) (string, error) {
-	t.tracker.addToolCall(t.inner.Name())
+	if t.tracker != nil {
+		t.tracker.addToolCall(t.inner.Name())
+	}
 	return t.inner.Execute(ctx, args)
 }
 


### PR DESCRIPTION
Fixes #305.

## Problem

`ExecutionSummary.UsedTools` and `ToolCalls` were populated with every tool that was *available* to the agent, not the tools the LLM actually chose to call. With a 40-tool MCP server and a prompt that triggered 2 tool calls, the summary reported all 40 as used.

The bug was in [pkg/agent/agent.go:1277-1279](pkg/agent/agent.go#L1277):
\`\`\`go
if tracker != nil {
    for _, tool := range tools {
        tracker.addToolCall(tool.Name())  // pre-populates every tool
    }
}
\`\`\`

## Fix

- New `pkg/agent/tracking_tool.go` introduces a `trackingTool` wrapper that records the call when its `Execute` or `Run` is invoked, then delegates to the inner tool. `DisplayName` and `Internal` are forwarded when the inner tool implements them.
- `wrapToolsWithTracker(tools, tracker)` returns wrapped tools (or the original slice if the tracker is nil).
- The non-streaming path and the streaming path now both wrap tools before passing to the LLM, replacing the pre-population loop.
- Updated the `MockLLMForDetailed.GenerateWithToolsDetailed` test mock to actually invoke each provided tool, so the existing assertion (`ToolCalls == 1`, `UsedTools` contains `test_tool`) reflects realistic behavior. Without this, the previous test was passing only because of the buggy pre-population.

## Test plan

- `go test ./pkg/agent/...` passes
- `go test ./...` passes