### PR TITLE
fix(tracing): emit TraceGeneration for non-streaming GenerateWithTools

### DIFF
--- a/pkg/tracing/traced_llm.go
+++ b/pkg/tracing/traced_llm.go
@@ -140,6 +140,27 @@ func (m *TracedLLM) GenerateWithTools(ctx context.Context, prompt string, tools 
 			span.RecordError(err)
 		}
 
+		// Mirror the streaming path: if any tool calls were collected, emit a
+		// generation span via TraceGeneration so Langfuse / OTEL backends record
+		// the call graph for non-streaming runs too (#295).
+		if toolCalls := GetToolCallsFromContext(ctx); len(toolCalls) > 0 {
+			responseText := response
+			if !m.shouldIncludeContent() {
+				responseText = "non_streaming_response"
+			}
+			if adapter, ok := m.tracer.(*OTELTracerAdapter); ok {
+				_, _ = adapter.otelTracer.TraceGeneration(ctx, model, prompt, responseText, startTime, endTime, map[string]any{ //nolint:gosec
+					"streaming": false,
+					"tools":     len(tools),
+				})
+			} else if tracer, ok := m.tracer.(*OTELLangfuseTracer); ok {
+				_, _ = tracer.TraceGeneration(ctx, model, prompt, responseText, startTime, endTime, map[string]any{ //nolint:gosec
+					"streaming": false,
+					"tools":     len(tools),
+				})
+			}
+		}
+
 		return response, err
 	}
 

--- a/pkg/tracing/traced_llm.go
+++ b/pkg/tracing/traced_llm.go
@@ -146,18 +146,24 @@ func (m *TracedLLM) GenerateWithTools(ctx context.Context, prompt string, tools 
 		if toolCalls := GetToolCallsFromContext(ctx); len(toolCalls) > 0 {
 			responseText := response
 			if !m.shouldIncludeContent() {
-				responseText = "non_streaming_response"
+				responseText = "<redacted>"
+			}
+			metadata := map[string]any{
+				"streaming": false,
+				"tools":     len(tools),
+			}
+			// Stamp the error so downstream backends can distinguish a
+			// failed generation from a successful one with empty content.
+			if err != nil {
+				metadata["error"] = err.Error()
+				if responseText == "" {
+					responseText = "<error>"
+				}
 			}
 			if adapter, ok := m.tracer.(*OTELTracerAdapter); ok {
-				_, _ = adapter.otelTracer.TraceGeneration(ctx, model, prompt, responseText, startTime, endTime, map[string]any{ //nolint:gosec
-					"streaming": false,
-					"tools":     len(tools),
-				})
+				_, _ = adapter.otelTracer.TraceGeneration(ctx, model, prompt, responseText, startTime, endTime, metadata) //nolint:gosec
 			} else if tracer, ok := m.tracer.(*OTELLangfuseTracer); ok {
-				_, _ = tracer.TraceGeneration(ctx, model, prompt, responseText, startTime, endTime, map[string]any{ //nolint:gosec
-					"streaming": false,
-					"tools":     len(tools),
-				})
+				_, _ = tracer.TraceGeneration(ctx, model, prompt, responseText, startTime, endTime, metadata) //nolint:gosec
 			}
 		}
 


### PR DESCRIPTION
Fixes #295.

## Problem

\`GenerateWithToolsStream\` (streaming path) calls \`TraceGeneration\` when the stream completes, so Langfuse and OTEL backends receive a generation span with the collected tool calls. The non-streaming \`GenerateWithTools\` initialized tool-call collection in context (\`WithToolCallsCollection(ctx)\`) but never emitted the corresponding generation, leaving non-streaming agent executions invisible in Langfuse.

## Fix

Mirror the streaming pattern in \`pkg/tracing/traced_llm.go\` \`GenerateWithTools\`: after the LLM call returns, if any tool calls were collected, emit \`TraceGeneration\` via the same \`OTELTracerAdapter\` / \`OTELLangfuseTracer\` path the streaming code uses. Respects \`shouldIncludeContent()\` for response visibility.

## Test plan

- \`go test ./pkg/tracing/...\` passes
- \`go test ./...\` passes
- Manual verification with Langfuse should show generation spans for non-streaming agent runs that invoke tools (verified by reporter)