### PR TITLE
fix(ollama): use native /api/chat tool calling instead of prompt stuffing

### DIFF
--- a/pkg/llm/ollama/client.go
+++ b/pkg/llm/ollama/client.go
@@ -315,14 +315,25 @@ func (c *OllamaClient) GenerateWithTools(ctx context.Context, prompt string, too
 		// Persist the assistant message that requested the tool calls.
 		messages = append(messages, chatResp.Message)
 
+		// Synthesize one ID per tool_call so the same tool invoked twice
+		// in a single turn doesn't collide on a shared "ollama:<name>" key.
+		// IDs are stable for the duration of the loop iteration; they're
+		// persisted on both the assistant ToolCall and the corresponding
+		// tool-result message so consumers can pair them later.
+		callIDs := make([]string, len(chatResp.Message.ToolCalls))
+		for idx, call := range chatResp.Message.ToolCalls {
+			callIDs[idx] = fmt.Sprintf("ollama:%s:%d:%d", call.Function.Name, iter, idx)
+		}
+
 		// Mirror the assistant tool-call message into Memory so subsequent
 		// agent turns can see the tool exchanges (matches OpenAI client
 		// convention; addresses the #325 review BLOCKER on memory loss).
 		if params.Memory != nil {
 			toolCallSummaries := make([]interfaces.ToolCall, 0, len(chatResp.Message.ToolCalls))
-			for _, call := range chatResp.Message.ToolCalls {
+			for idx, call := range chatResp.Message.ToolCalls {
 				argsBytes, _ := json.Marshal(call.Function.Arguments)
 				toolCallSummaries = append(toolCallSummaries, interfaces.ToolCall{
+					ID:        callIDs[idx],
 					Name:      call.Function.Name,
 					Arguments: string(argsBytes),
 				})
@@ -335,12 +346,13 @@ func (c *OllamaClient) GenerateWithTools(ctx context.Context, prompt string, too
 		}
 
 		// Execute each tool call and append its result as a tool message.
-		for _, call := range chatResp.Message.ToolCalls {
+		for idx, call := range chatResp.Message.ToolCalls {
+			callID := callIDs[idx]
 			tool := findToolByName(tools, call.Function.Name)
 			if tool == nil {
 				errMsg := fmt.Sprintf("error: tool %q not found", call.Function.Name)
 				messages = append(messages, ChatMessage{Role: "tool", Content: errMsg})
-				persistToolResultMessage(ctx, params.Memory, call.Function.Name, errMsg)
+				persistToolResultMessage(ctx, params.Memory, callID, call.Function.Name, errMsg)
 				continue
 			}
 
@@ -348,7 +360,7 @@ func (c *OllamaClient) GenerateWithTools(ctx context.Context, prompt string, too
 			if err != nil {
 				errMsg := fmt.Sprintf("error: failed to encode arguments: %v", err)
 				messages = append(messages, ChatMessage{Role: "tool", Content: errMsg})
-				persistToolResultMessage(ctx, params.Memory, call.Function.Name, errMsg)
+				persistToolResultMessage(ctx, params.Memory, callID, call.Function.Name, errMsg)
 				continue
 			}
 
@@ -356,12 +368,12 @@ func (c *OllamaClient) GenerateWithTools(ctx context.Context, prompt string, too
 			if err != nil {
 				errMsg := fmt.Sprintf("error: %v", err)
 				messages = append(messages, ChatMessage{Role: "tool", Content: errMsg})
-				persistToolResultMessage(ctx, params.Memory, call.Function.Name, errMsg)
+				persistToolResultMessage(ctx, params.Memory, callID, call.Function.Name, errMsg)
 				continue
 			}
 
 			messages = append(messages, ChatMessage{Role: "tool", Content: result})
-			persistToolResultMessage(ctx, params.Memory, call.Function.Name, result)
+			persistToolResultMessage(ctx, params.Memory, callID, call.Function.Name, result)
 		}
 	}
 
@@ -425,18 +437,19 @@ func findToolByName(tools []interfaces.Tool, name string) interfaces.Tool {
 }
 
 // persistToolResultMessage records a tool result message in Memory so the
-// next agent turn can replay the tool exchange. Ollama's wire format
-// doesn't carry tool-call IDs, so we synthesize one from the tool name —
-// BuildInlineHistoryPrompt requires a non-empty ToolCallID to render the
-// message back into the inlined history on the next turn.
-func persistToolResultMessage(ctx context.Context, mem interfaces.Memory, toolName, content string) {
+// next agent turn can replay the tool exchange. callID is synthesized by
+// the caller per invocation (not per tool name) so the same tool called
+// twice in one assistant turn doesn't share an ID. BuildInlineHistoryPrompt
+// requires a non-empty ToolCallID to render the message back into the
+// inlined history on the next turn.
+func persistToolResultMessage(ctx context.Context, mem interfaces.Memory, callID, toolName, content string) {
 	if mem == nil {
 		return
 	}
 	_ = mem.AddMessage(ctx, interfaces.Message{
 		Role:       interfaces.MessageRoleTool,
 		Content:    content,
-		ToolCallID: "ollama:" + toolName,
+		ToolCallID: callID,
 		Metadata: map[string]interface{}{
 			"tool_name": toolName,
 		},

--- a/pkg/llm/ollama/client.go
+++ b/pkg/llm/ollama/client.go
@@ -315,36 +315,53 @@ func (c *OllamaClient) GenerateWithTools(ctx context.Context, prompt string, too
 		// Persist the assistant message that requested the tool calls.
 		messages = append(messages, chatResp.Message)
 
+		// Mirror the assistant tool-call message into Memory so subsequent
+		// agent turns can see the tool exchanges (matches OpenAI client
+		// convention; addresses the #325 review BLOCKER on memory loss).
+		if params.Memory != nil {
+			toolCallSummaries := make([]interfaces.ToolCall, 0, len(chatResp.Message.ToolCalls))
+			for _, call := range chatResp.Message.ToolCalls {
+				argsBytes, _ := json.Marshal(call.Function.Arguments)
+				toolCallSummaries = append(toolCallSummaries, interfaces.ToolCall{
+					Name:      call.Function.Name,
+					Arguments: string(argsBytes),
+				})
+			}
+			_ = params.Memory.AddMessage(ctx, interfaces.Message{
+				Role:      interfaces.MessageRoleAssistant,
+				Content:   chatResp.Message.Content,
+				ToolCalls: toolCallSummaries,
+			})
+		}
+
 		// Execute each tool call and append its result as a tool message.
 		for _, call := range chatResp.Message.ToolCalls {
 			tool := findToolByName(tools, call.Function.Name)
 			if tool == nil {
-				messages = append(messages, ChatMessage{
-					Role:    "tool",
-					Content: fmt.Sprintf("error: tool %q not found", call.Function.Name),
-				})
+				errMsg := fmt.Sprintf("error: tool %q not found", call.Function.Name)
+				messages = append(messages, ChatMessage{Role: "tool", Content: errMsg})
+				persistToolResultMessage(ctx, params.Memory, call.Function.Name, errMsg)
 				continue
 			}
 
 			argsJSON, err := json.Marshal(call.Function.Arguments)
 			if err != nil {
-				messages = append(messages, ChatMessage{
-					Role:    "tool",
-					Content: fmt.Sprintf("error: failed to encode arguments: %v", err),
-				})
+				errMsg := fmt.Sprintf("error: failed to encode arguments: %v", err)
+				messages = append(messages, ChatMessage{Role: "tool", Content: errMsg})
+				persistToolResultMessage(ctx, params.Memory, call.Function.Name, errMsg)
 				continue
 			}
 
 			result, err := tool.Execute(ctx, string(argsJSON))
 			if err != nil {
-				messages = append(messages, ChatMessage{
-					Role:    "tool",
-					Content: fmt.Sprintf("error: %v", err),
-				})
+				errMsg := fmt.Sprintf("error: %v", err)
+				messages = append(messages, ChatMessage{Role: "tool", Content: errMsg})
+				persistToolResultMessage(ctx, params.Memory, call.Function.Name, errMsg)
 				continue
 			}
 
 			messages = append(messages, ChatMessage{Role: "tool", Content: result})
+			persistToolResultMessage(ctx, params.Memory, call.Function.Name, result)
 		}
 	}
 
@@ -363,6 +380,9 @@ func toolParametersToJSONSchema(params map[string]interfaces.ParameterSpec) map[
 		}
 		if spec.Description != "" {
 			field["description"] = spec.Description
+		}
+		if spec.Default != nil {
+			field["default"] = spec.Default
 		}
 		if spec.Enum != nil {
 			field["enum"] = spec.Enum
@@ -402,6 +422,25 @@ func findToolByName(tools []interfaces.Tool, name string) interfaces.Tool {
 		}
 	}
 	return nil
+}
+
+// persistToolResultMessage records a tool result message in Memory so the
+// next agent turn can replay the tool exchange. Ollama's wire format
+// doesn't carry tool-call IDs, so we synthesize one from the tool name —
+// BuildInlineHistoryPrompt requires a non-empty ToolCallID to render the
+// message back into the inlined history on the next turn.
+func persistToolResultMessage(ctx context.Context, mem interfaces.Memory, toolName, content string) {
+	if mem == nil {
+		return
+	}
+	_ = mem.AddMessage(ctx, interfaces.Message{
+		Role:       interfaces.MessageRoleTool,
+		Content:    content,
+		ToolCallID: "ollama:" + toolName,
+		Metadata: map[string]interface{}{
+			"tool_name": toolName,
+		},
+	})
 }
 
 // Chat performs a chat completion with messages

--- a/pkg/llm/ollama/client.go
+++ b/pkg/llm/ollama/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
@@ -125,14 +124,38 @@ type ChatRequest struct {
 	Model     string        `json:"model"`
 	Messages  []ChatMessage `json:"messages"`
 	Stream    bool          `json:"stream"`
+	Tools     []OllamaTool  `json:"tools,omitempty"`
 	Options   *Options      `json:"options,omitempty"`
 	Format    string        `json:"format,omitempty"`
 	KeepAlive string        `json:"keep_alive,omitempty"`
 }
 
 type ChatMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role      string           `json:"role"`
+	Content   string           `json:"content"`
+	ToolCalls []OllamaToolCall `json:"tool_calls,omitempty"`
+}
+
+// OllamaTool is a function declaration sent to /api/chat for native tool use.
+type OllamaTool struct {
+	Type     string         `json:"type"`
+	Function OllamaFunction `json:"function"`
+}
+
+type OllamaFunction struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Parameters  map[string]interface{} `json:"parameters"`
+}
+
+// OllamaToolCall is a function invocation requested by the model in /api/chat.
+type OllamaToolCall struct {
+	Function OllamaToolCallFunction `json:"function"`
+}
+
+type OllamaToolCallFunction struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments"`
 }
 
 type ChatResponse struct {
@@ -215,29 +238,170 @@ Ensure your response is a valid JSON object that strictly follows the schema abo
 	return generateResp.Response, nil
 }
 
-// GenerateWithTools generates text and can use tools
+// GenerateWithTools generates text using Ollama's native /api/chat tool support.
+// The model is given the full tool list and may invoke any subset; we execute each
+// returned tool_call and feed the result back as a tool message until the model
+// returns a final answer with no further tool calls (#202).
 func (c *OllamaClient) GenerateWithTools(ctx context.Context, prompt string, tools []interfaces.Tool, options ...interfaces.GenerateOption) (string, error) {
-	// For now, Ollama doesn't support tool calling in the same way as OpenAI/Anthropic
-	// We'll implement a basic version that includes tool descriptions in the prompt
 	if len(tools) == 0 {
 		return c.Generate(ctx, prompt, options...)
 	}
 
-	// Build tool descriptions
-	var toolDescriptions []string
-	for _, tool := range tools {
-		toolDescriptions = append(toolDescriptions, fmt.Sprintf("- %s: %s", tool.Name(), tool.Description()))
+	params := &interfaces.GenerateOptions{
+		LLMConfig: &interfaces.LLMConfig{Temperature: 0.7},
+	}
+	for _, option := range options {
+		option(params)
 	}
 
-	// Create enhanced prompt with tool information
-	enhancedPrompt := fmt.Sprintf(`%s
+	// Build initial conversation. Memory history is inlined into the user
+	// prompt (same convention as Generate) so we don't need a separate
+	// per-turn history schema for the chat endpoint.
+	messages := make([]ChatMessage, 0, 4)
+	if params.SystemMessage != "" {
+		messages = append(messages, ChatMessage{Role: "system", Content: params.SystemMessage})
+	}
+	messages = append(messages, ChatMessage{
+		Role:    "user",
+		Content: c.buildPromptWithMemory(ctx, prompt, params),
+	})
 
-Available tools:
-%s
+	// Convert agent tools to Ollama function declarations
+	ollamaTools := make([]OllamaTool, 0, len(tools))
+	for _, t := range tools {
+		ollamaTools = append(ollamaTools, OllamaTool{
+			Type: "function",
+			Function: OllamaFunction{
+				Name:        t.Name(),
+				Description: t.Description(),
+				Parameters:  toolParametersToJSONSchema(t.Parameters()),
+			},
+		})
+	}
 
-Please respond to the user's request. If you need to use any tools, describe what you would do.`, prompt, strings.Join(toolDescriptions, "\n"))
+	maxIterations := params.MaxIterations
+	if maxIterations <= 0 {
+		maxIterations = 10
+	}
 
-	return c.Generate(ctx, enhancedPrompt, options...)
+	for iter := 0; iter < maxIterations; iter++ {
+		req := ChatRequest{
+			Model:    c.Model,
+			Messages: messages,
+			Stream:   false,
+			Tools:    ollamaTools,
+			Options: &Options{
+				Temperature: params.LLMConfig.Temperature,
+				TopP:        params.LLMConfig.TopP,
+				Stop:        params.LLMConfig.StopSequences,
+			},
+		}
+
+		resp, err := c.makeRequest(ctx, "/api/chat", req)
+		if err != nil {
+			return "", fmt.Errorf("failed to chat with tools: %w", err)
+		}
+
+		var chatResp ChatResponse
+		if err := json.Unmarshal(resp, &chatResp); err != nil {
+			return "", fmt.Errorf("failed to unmarshal tool-chat response: %w", err)
+		}
+
+		// No tool calls means the model produced its final answer.
+		if len(chatResp.Message.ToolCalls) == 0 {
+			return chatResp.Message.Content, nil
+		}
+
+		// Persist the assistant message that requested the tool calls.
+		messages = append(messages, chatResp.Message)
+
+		// Execute each tool call and append its result as a tool message.
+		for _, call := range chatResp.Message.ToolCalls {
+			tool := findToolByName(tools, call.Function.Name)
+			if tool == nil {
+				messages = append(messages, ChatMessage{
+					Role:    "tool",
+					Content: fmt.Sprintf("error: tool %q not found", call.Function.Name),
+				})
+				continue
+			}
+
+			argsJSON, err := json.Marshal(call.Function.Arguments)
+			if err != nil {
+				messages = append(messages, ChatMessage{
+					Role:    "tool",
+					Content: fmt.Sprintf("error: failed to encode arguments: %v", err),
+				})
+				continue
+			}
+
+			result, err := tool.Execute(ctx, string(argsJSON))
+			if err != nil {
+				messages = append(messages, ChatMessage{
+					Role:    "tool",
+					Content: fmt.Sprintf("error: %v", err),
+				})
+				continue
+			}
+
+			messages = append(messages, ChatMessage{Role: "tool", Content: result})
+		}
+	}
+
+	return "", fmt.Errorf("ollama tool loop exceeded max iterations (%d)", maxIterations)
+}
+
+// toolParametersToJSONSchema converts the SDK's ParameterSpec map into the JSON
+// Schema object Ollama expects under function.parameters.
+func toolParametersToJSONSchema(params map[string]interfaces.ParameterSpec) map[string]interface{} {
+	properties := make(map[string]interface{}, len(params))
+	required := make([]string, 0)
+	for name, spec := range params {
+		field := map[string]interface{}{}
+		if spec.Type != nil {
+			field["type"] = spec.Type
+		}
+		if spec.Description != "" {
+			field["description"] = spec.Description
+		}
+		if spec.Enum != nil {
+			field["enum"] = spec.Enum
+		}
+		if spec.Items != nil {
+			itemSchema := map[string]interface{}{}
+			if spec.Items.Type != nil {
+				itemSchema["type"] = spec.Items.Type
+			}
+			if spec.Items.Description != "" {
+				itemSchema["description"] = spec.Items.Description
+			}
+			if spec.Items.Enum != nil {
+				itemSchema["enum"] = spec.Items.Enum
+			}
+			field["items"] = itemSchema
+		}
+		properties[name] = field
+		if spec.Required {
+			required = append(required, name)
+		}
+	}
+	schema := map[string]interface{}{
+		"type":       "object",
+		"properties": properties,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+func findToolByName(tools []interfaces.Tool, name string) interfaces.Tool {
+	for _, t := range tools {
+		if t.Name() == name {
+			return t
+		}
+	}
+	return nil
 }
 
 // Chat performs a chat completion with messages

--- a/pkg/llm/ollama/client_test.go
+++ b/pkg/llm/ollama/client_test.go
@@ -387,6 +387,58 @@ func TestGenerateWithTools_PersistsToolExchangesToMemory(t *testing.T) {
 	assert.Equal(t, "calc", tool.Metadata["tool_name"])
 }
 
+// TestGenerateWithTools_ParallelCallsGetUniqueIDs covers the case where
+// the model invokes the same tool twice in a single assistant turn. Each
+// invocation must get a unique synthesized ToolCallID; otherwise the
+// memory pairing between assistant tool_call and tool result is broken.
+func TestGenerateWithTools_ParallelCallsGetUniqueIDs(t *testing.T) {
+	turn := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		var resp ChatResponse
+		switch turn {
+		case 0:
+			// Same tool invoked twice in a single assistant message.
+			resp = ChatResponse{Message: ChatMessage{
+				Role: "assistant",
+				ToolCalls: []OllamaToolCall{
+					{Function: OllamaToolCallFunction{Name: "calc", Arguments: map[string]interface{}{"expr": "1+1"}}},
+					{Function: OllamaToolCallFunction{Name: "calc", Arguments: map[string]interface{}{"expr": "2+2"}}},
+				},
+			}, Done: true}
+		case 1:
+			resp = ChatResponse{Message: ChatMessage{Role: "assistant", Content: "done"}, Done: true}
+		}
+		turn++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	mem := newRecordingMemory()
+	client := NewClient(WithModel("test-model"), WithBaseURL(server.URL))
+	_, err := client.GenerateWithTools(context.Background(), "do both",
+		[]interfaces.Tool{&mockTool{name: "calc", description: "calculator", runResult: "ok"}},
+		interfaces.WithMemory(mem),
+	)
+	require.NoError(t, err)
+
+	// One assistant message + two tool result messages
+	require.Len(t, mem.added, 3)
+	asst := mem.added[0]
+	require.Len(t, asst.ToolCalls, 2)
+	assert.NotEqual(t, asst.ToolCalls[0].ID, asst.ToolCalls[1].ID,
+		"parallel calls must get unique synthesized IDs")
+
+	tool1, tool2 := mem.added[1], mem.added[2]
+	assert.Equal(t, asst.ToolCalls[0].ID, tool1.ToolCallID,
+		"first tool result ID must match first assistant tool_call ID")
+	assert.Equal(t, asst.ToolCalls[1].ID, tool2.ToolCallID,
+		"second tool result ID must match second assistant tool_call ID")
+	assert.NotEqual(t, tool1.ToolCallID, tool2.ToolCallID)
+}
+
 // recordingMemory is a minimal in-memory Memory that captures every
 // message added to it for assertion in tests.
 type recordingMemory struct {

--- a/pkg/llm/ollama/client_test.go
+++ b/pkg/llm/ollama/client_test.go
@@ -172,23 +172,60 @@ func TestChat(t *testing.T) {
 }
 
 func TestGenerateWithTools(t *testing.T) {
+	// First request: model returns tool_calls. Second request (after we
+	// feed back the tool result): model returns the final answer with no
+	// further tool calls.
+	turn := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req GenerateRequest
+		assert.Equal(t, "/api/chat", r.URL.Path)
+
+		var req ChatRequest
 		err := json.NewDecoder(r.Body).Decode(&req)
 		require.NoError(t, err)
 
-		// Check that the prompt includes tool descriptions
-		assert.Contains(t, req.Prompt, "Available tools:")
-		assert.Contains(t, req.Prompt, "- test-tool: A test tool")
+		// Tool definitions must be sent on every request.
+		require.Len(t, req.Tools, 1)
+		assert.Equal(t, "function", req.Tools[0].Type)
+		assert.Equal(t, "test-tool", req.Tools[0].Function.Name)
+		assert.Equal(t, "A test tool", req.Tools[0].Function.Description)
 
-		response := GenerateResponse{
-			Model:    "test-model",
-			Response: "I can help you with that using the available tools",
-			Done:     true,
+		var resp ChatResponse
+		switch turn {
+		case 0:
+			// First call: model decides to invoke the tool.
+			resp = ChatResponse{
+				Model: "test-model",
+				Message: ChatMessage{
+					Role: "assistant",
+					ToolCalls: []OllamaToolCall{{
+						Function: OllamaToolCallFunction{
+							Name:      "test-tool",
+							Arguments: map[string]interface{}{"q": "hello"},
+						},
+					}},
+				},
+				Done: true,
+			}
+		case 1:
+			// Second call: conversation now includes the tool result.
+			require.GreaterOrEqual(t, len(req.Messages), 3)
+			assert.Equal(t, "tool", req.Messages[len(req.Messages)-1].Role)
+			assert.Equal(t, "tool result", req.Messages[len(req.Messages)-1].Content)
+			resp = ChatResponse{
+				Model: "test-model",
+				Message: ChatMessage{
+					Role:    "assistant",
+					Content: "I can help you with that using the available tools",
+				},
+				Done: true,
+			}
+		default:
+			t.Fatalf("unexpected extra request, turn=%d", turn)
 		}
+		turn++
 
 		w.Header().Set("Content-Type", "application/json")
-		err = json.NewEncoder(w).Encode(response)
+		err = json.NewEncoder(w).Encode(resp)
 		require.NoError(t, err)
 	}))
 	defer server.Close()
@@ -198,22 +235,21 @@ func TestGenerateWithTools(t *testing.T) {
 		WithBaseURL(server.URL),
 	)
 
-	// Create a mock tool
 	mockTool := &mockTool{
 		name:        "test-tool",
 		description: "A test tool",
+		runResult:   "tool result",
 	}
-
-	tools := []interfaces.Tool{mockTool}
 
 	response, err := client.GenerateWithTools(
 		context.Background(),
 		"Help me with something",
-		tools,
+		[]interfaces.Tool{mockTool},
 	)
 
 	require.NoError(t, err)
 	assert.Equal(t, "I can help you with that using the available tools", response)
+	assert.Equal(t, 2, turn, "expected exactly two roundtrips")
 }
 
 func TestListModels(t *testing.T) {
@@ -310,6 +346,7 @@ func TestName(t *testing.T) {
 type mockTool struct {
 	name        string
 	description string
+	runResult   string
 }
 
 func (t *mockTool) Name() string {
@@ -329,6 +366,9 @@ func (t *mockTool) Internal() bool {
 }
 
 func (t *mockTool) Run(ctx context.Context, input string) (string, error) {
+	if t.runResult != "" {
+		return t.runResult, nil
+	}
 	return "mock result", nil
 }
 
@@ -343,6 +383,9 @@ func (t *mockTool) Parameters() map[string]interfaces.ParameterSpec {
 }
 
 func (t *mockTool) Execute(ctx context.Context, args string) (string, error) {
+	if t.runResult != "" {
+		return t.runResult, nil
+	}
 	return "mock result", nil
 }
 

--- a/pkg/llm/ollama/client_test.go
+++ b/pkg/llm/ollama/client_test.go
@@ -252,6 +252,163 @@ func TestGenerateWithTools(t *testing.T) {
 	assert.Equal(t, 2, turn, "expected exactly two roundtrips")
 }
 
+// TestGenerateWithTools_NoToolCalls covers the happy path where the model
+// responds with a final answer on the first turn — no loop iterations.
+func TestGenerateWithTools_NoToolCalls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ChatResponse{
+			Model:   "test-model",
+			Message: ChatMessage{Role: "assistant", Content: "I can answer directly"},
+			Done:    true,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithModel("test-model"), WithBaseURL(server.URL))
+	resp, err := client.GenerateWithTools(context.Background(), "hello",
+		[]interfaces.Tool{&mockTool{name: "noop", description: "noop"}})
+	require.NoError(t, err)
+	assert.Equal(t, "I can answer directly", resp)
+}
+
+// TestGenerateWithTools_MaxIterationsExceeded ensures we bound runaway
+// loops when the model keeps requesting tools.
+func TestGenerateWithTools_MaxIterationsExceeded(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ChatResponse{
+			Model: "test-model",
+			Message: ChatMessage{
+				Role: "assistant",
+				ToolCalls: []OllamaToolCall{{
+					Function: OllamaToolCallFunction{Name: "noop", Arguments: map[string]interface{}{}},
+				}},
+			},
+			Done: true,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithModel("test-model"), WithBaseURL(server.URL))
+	_, err := client.GenerateWithTools(context.Background(), "loop",
+		[]interfaces.Tool{&mockTool{name: "noop", description: "noop", runResult: "ok"}},
+		interfaces.WithMaxIterations(2),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max iterations")
+}
+
+// TestGenerateWithTools_ToolNotFound feeds an error message back to the
+// model when it hallucinates a tool name and continues the loop instead
+// of failing the whole call.
+func TestGenerateWithTools_ToolNotFound(t *testing.T) {
+	turn := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		var resp ChatResponse
+		switch turn {
+		case 0:
+			resp = ChatResponse{Message: ChatMessage{
+				Role: "assistant",
+				ToolCalls: []OllamaToolCall{{
+					Function: OllamaToolCallFunction{Name: "ghost_tool", Arguments: map[string]interface{}{}},
+				}},
+			}, Done: true}
+		case 1:
+			require.GreaterOrEqual(t, len(req.Messages), 2)
+			last := req.Messages[len(req.Messages)-1]
+			assert.Equal(t, "tool", last.Role)
+			assert.Contains(t, last.Content, "ghost_tool")
+			assert.Contains(t, last.Content, "not found")
+			resp = ChatResponse{Message: ChatMessage{Role: "assistant", Content: "I'll skip that"}, Done: true}
+		}
+		turn++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithModel("test-model"), WithBaseURL(server.URL))
+	resp, err := client.GenerateWithTools(context.Background(), "hi",
+		[]interfaces.Tool{&mockTool{name: "real_tool", description: "the real one"}})
+	require.NoError(t, err)
+	assert.Equal(t, "I'll skip that", resp)
+}
+
+// TestGenerateWithTools_PersistsToolExchangesToMemory is the regression
+// test for the #325 review BLOCKER: across multi-turn conversations the
+// tool exchange must end up in Memory so the next turn can replay it via
+// BuildInlineHistoryPrompt.
+func TestGenerateWithTools_PersistsToolExchangesToMemory(t *testing.T) {
+	turn := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		var resp ChatResponse
+		switch turn {
+		case 0:
+			resp = ChatResponse{Message: ChatMessage{
+				Role: "assistant",
+				ToolCalls: []OllamaToolCall{{
+					Function: OllamaToolCallFunction{Name: "calc", Arguments: map[string]interface{}{"expr": "1+1"}},
+				}},
+			}, Done: true}
+		case 1:
+			resp = ChatResponse{Message: ChatMessage{Role: "assistant", Content: "the answer is 2"}, Done: true}
+		}
+		turn++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	mem := newRecordingMemory()
+	client := NewClient(WithModel("test-model"), WithBaseURL(server.URL))
+	_, err := client.GenerateWithTools(context.Background(), "what is 1+1",
+		[]interfaces.Tool{&mockTool{name: "calc", description: "calculator", runResult: "2"}},
+		interfaces.WithMemory(mem),
+	)
+	require.NoError(t, err)
+
+	require.Len(t, mem.added, 2, "expected assistant tool-call message + tool result message")
+
+	asst := mem.added[0]
+	assert.Equal(t, interfaces.MessageRoleAssistant, asst.Role)
+	require.Len(t, asst.ToolCalls, 1)
+	assert.Equal(t, "calc", asst.ToolCalls[0].Name)
+	assert.Contains(t, asst.ToolCalls[0].Arguments, `"expr":"1+1"`)
+
+	tool := mem.added[1]
+	assert.Equal(t, interfaces.MessageRoleTool, tool.Role)
+	assert.Equal(t, "2", tool.Content)
+	assert.NotEmpty(t, tool.ToolCallID, "ToolCallID required for BuildInlineHistoryPrompt to render the tool message back")
+	assert.Equal(t, "calc", tool.Metadata["tool_name"])
+}
+
+// recordingMemory is a minimal in-memory Memory that captures every
+// message added to it for assertion in tests.
+type recordingMemory struct {
+	added []interfaces.Message
+}
+
+func newRecordingMemory() *recordingMemory { return &recordingMemory{} }
+
+func (m *recordingMemory) AddMessage(_ context.Context, msg interfaces.Message) error {
+	m.added = append(m.added, msg)
+	return nil
+}
+
+func (m *recordingMemory) GetMessages(_ context.Context, _ ...interfaces.GetMessagesOption) ([]interfaces.Message, error) {
+	return m.added, nil
+}
+
+func (m *recordingMemory) Clear(_ context.Context) error {
+	m.added = nil
+	return nil
+}
+
 func TestListModels(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)

--- a/pkg/tracing/traced_llm.go
+++ b/pkg/tracing/traced_llm.go
@@ -140,6 +140,27 @@ func (m *TracedLLM) GenerateWithTools(ctx context.Context, prompt string, tools 
 			span.RecordError(err)
 		}
 
+		// Mirror the streaming path: if any tool calls were collected, emit a
+		// generation span via TraceGeneration so Langfuse / OTEL backends record
+		// the call graph for non-streaming runs too (#295).
+		if toolCalls := GetToolCallsFromContext(ctx); len(toolCalls) > 0 {
+			responseText := response
+			if !m.shouldIncludeContent() {
+				responseText = "non_streaming_response"
+			}
+			if adapter, ok := m.tracer.(*OTELTracerAdapter); ok {
+				_, _ = adapter.otelTracer.TraceGeneration(ctx, model, prompt, responseText, startTime, endTime, map[string]any{ //nolint:gosec
+					"streaming": false,
+					"tools":     len(tools),
+				})
+			} else if tracer, ok := m.tracer.(*OTELLangfuseTracer); ok {
+				_, _ = tracer.TraceGeneration(ctx, model, prompt, responseText, startTime, endTime, map[string]any{ //nolint:gosec
+					"streaming": false,
+					"tools":     len(tools),
+				})
+			}
+		}
+
 		return response, err
 	}
 


### PR DESCRIPTION
Fixes #202.

## Problem

\`OllamaClient.GenerateWithTools\` just appended tool descriptions to the user prompt and asked the model to "describe what you would do" — actual tool invocation never happened. From [pkg/llm/ollama/client.go](pkg/llm/ollama/client.go) before this PR:

\`\`\`go
// For now, Ollama doesn't support tool calling in the same way as OpenAI/Anthropic
// We'll implement a basic version that includes tool descriptions in the prompt
\`\`\`

So MCP tools were silently inert when an agent was wired with an Ollama LLM — the same setup worked fine with OpenAI/Anthropic, as the bug report noted.

## Fix

Ollama added native function calling in \`/api/chat\` (≥0.1.32, March 2024). Replace the prompt-stuffing implementation with the real protocol:

1. Convert agent tools to \`OllamaTool\` function declarations. JSON Schema is generated from \`ParameterSpec\`, including \`items\`, \`enum\`, and \`required\`.
2. Send chat requests with the \`tools\` array.
3. When the response contains \`tool_calls\`, execute each tool via \`tool.Execute(ctx, args)\`, append the assistant message + tool result messages to the conversation, and loop.
4. Return when the model produces a final response with no further calls.
5. Bound the loop with \`MaxIterations\` (default 10) so a misbehaving model can't run away.

Memory history is still inlined into the user prompt (same convention as \`Generate\`) — reworking memory storage for chat-format messages would be a separate, larger change.

## Test plan

- Updated \`TestGenerateWithTools\` to drive the new two-turn protocol against a fake \`/api/chat\` server: first turn returns \`tool_calls\`, second turn (after we feed back the tool result message) returns the final answer. Asserts that exactly two roundtrips happen and that the tool result message reaches the model.
- Added \`runResult\` to the in-package \`mockTool\` for the assertion.
- \`go test ./pkg/llm/ollama/...\` passes
- \`go test ./...\` passes