### PR TITLE
fix(openai): aggregate token usage across tool-loop iterations

### DIFF
--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -572,6 +572,18 @@ func (c *OpenAIClient) GenerateWithTools(ctx context.Context, prompt string, too
 			return "", fmt.Errorf("no completions returned")
 		}
 
+		// Accumulate per-iteration token usage so GenerateWithToolsDetailed
+		// can report a total that reflects every underlying call (#276).
+		if acc := getUsageAccumulator(ctx); acc != nil {
+			acc.add(
+				int(resp.Usage.PromptTokens),
+				int(resp.Usage.CompletionTokens),
+				int(resp.Usage.TotalTokens),
+				int(resp.Usage.CompletionTokensDetails.ReasoningTokens),
+				c.Model,
+			)
+		}
+
 		// Capture the last content from the response
 		lastContent = strings.TrimSpace(resp.Choices[0].Message.Content)
 
@@ -986,6 +998,16 @@ func (c *OpenAIClient) GenerateWithTools(ctx context.Context, prompt string, too
 		return "", fmt.Errorf("no completions returned in final call")
 	}
 
+	if acc := getUsageAccumulator(ctx); acc != nil {
+		acc.add(
+			int(finalResp.Usage.PromptTokens),
+			int(finalResp.Usage.CompletionTokens),
+			int(finalResp.Usage.TotalTokens),
+			int(finalResp.Usage.CompletionTokensDetails.ReasoningTokens),
+			c.Model,
+		)
+	}
+
 	content := strings.TrimSpace(finalResp.Choices[0].Message.Content)
 	c.logger.Info(ctx, "Successfully received final response without tools", nil)
 	return content, nil
@@ -1073,22 +1095,30 @@ func (c *OpenAIClient) GenerateDetailed(ctx context.Context, prompt string, opti
 	return c.generateInternal(ctx, prompt, options...)
 }
 
-// GenerateWithToolsDetailed generates text with tools and returns detailed response information including token usage
+// GenerateWithToolsDetailed generates text with tools and returns detailed
+// response information, including token usage aggregated across every
+// underlying chat completion (each tool-loop iteration plus the final
+// summary call). Without this, RunDetailed reported zero tokens whenever
+// the agent had tools — including any MCP-equipped agent (#276).
 func (c *OpenAIClient) GenerateWithToolsDetailed(ctx context.Context, prompt string, tools []interfaces.Tool, options ...interfaces.GenerateOption) (*interfaces.LLMResponse, error) {
-	// For now, call the existing method and construct a detailed response
-	// TODO: Implement full detailed version that tracks token usage across all tool iterations
+	acc := &usageAccumulator{}
+	ctx = withUsageAccumulator(ctx, acc)
+
 	content, err := c.GenerateWithTools(ctx, prompt, tools, options...)
 	if err != nil {
 		return nil, err
 	}
 
-	// Return a basic detailed response without usage information for now
-	// This will be enhanced to track usage across all tool iterations
+	usage, model, _ := acc.snapshot()
+	if model == "" {
+		model = c.Model
+	}
+
 	return &interfaces.LLMResponse{
 		Content:    content,
-		Model:      c.Model,
+		Model:      model,
 		StopReason: "",
-		Usage:      nil, // TODO: Implement token usage tracking for tool iterations
+		Usage:      usage,
 		Metadata: map[string]interface{}{
 			"provider":   "openai",
 			"tools_used": true,

--- a/pkg/llm/openai/usage_accumulator.go
+++ b/pkg/llm/openai/usage_accumulator.go
@@ -1,0 +1,54 @@
+package openai
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// usageAccumulator collects token usage across the multiple API calls a
+// single GenerateWithTools invocation makes (one per tool-loop iteration
+// plus the final summary). Lets GenerateWithToolsDetailed return a
+// total that reflects every underlying chat completion, not just the
+// last one (#276).
+type usageAccumulator struct {
+	mu      sync.Mutex
+	total   interfaces.TokenUsage
+	model   string
+	touched bool
+}
+
+func (u *usageAccumulator) add(input, output, total, reasoning int, model string) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.total.InputTokens += input
+	u.total.OutputTokens += output
+	u.total.TotalTokens += total
+	u.total.ReasoningTokens += reasoning
+	if u.model == "" {
+		u.model = model
+	}
+	u.touched = true
+}
+
+func (u *usageAccumulator) snapshot() (*interfaces.TokenUsage, string, bool) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if !u.touched {
+		return nil, "", false
+	}
+	t := u.total
+	return &t, u.model, true
+}
+
+type usageCtxKey struct{}
+
+func withUsageAccumulator(ctx context.Context, acc *usageAccumulator) context.Context {
+	return context.WithValue(ctx, usageCtxKey{}, acc)
+}
+
+func getUsageAccumulator(ctx context.Context) *usageAccumulator {
+	acc, _ := ctx.Value(usageCtxKey{}).(*usageAccumulator)
+	return acc
+}

--- a/pkg/llm/openai/usage_accumulator_test.go
+++ b/pkg/llm/openai/usage_accumulator_test.go
@@ -1,0 +1,56 @@
+package openai
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUsageAccumulator_AccumulatesAcrossCalls(t *testing.T) {
+	acc := &usageAccumulator{}
+	acc.add(10, 5, 15, 0, "gpt-4o")
+	acc.add(20, 8, 28, 2, "gpt-4o")
+
+	usage, model, ok := acc.snapshot()
+	if !ok {
+		t.Fatal("expected accumulator to be marked touched")
+	}
+	if usage.InputTokens != 30 {
+		t.Errorf("InputTokens = %d, want 30", usage.InputTokens)
+	}
+	if usage.OutputTokens != 13 {
+		t.Errorf("OutputTokens = %d, want 13", usage.OutputTokens)
+	}
+	if usage.TotalTokens != 43 {
+		t.Errorf("TotalTokens = %d, want 43", usage.TotalTokens)
+	}
+	if usage.ReasoningTokens != 2 {
+		t.Errorf("ReasoningTokens = %d, want 2", usage.ReasoningTokens)
+	}
+	if model != "gpt-4o" {
+		t.Errorf("model = %q, want gpt-4o", model)
+	}
+}
+
+func TestUsageAccumulator_UntouchedReturnsNil(t *testing.T) {
+	acc := &usageAccumulator{}
+	usage, _, ok := acc.snapshot()
+	if ok {
+		t.Errorf("expected !ok for untouched accumulator")
+	}
+	if usage != nil {
+		t.Errorf("expected nil usage, got %+v", usage)
+	}
+}
+
+func TestUsageAccumulator_ContextRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	if got := getUsageAccumulator(ctx); got != nil {
+		t.Errorf("expected nil from empty ctx, got %p", got)
+	}
+
+	acc := &usageAccumulator{}
+	ctx = withUsageAccumulator(ctx, acc)
+	if got := getUsageAccumulator(ctx); got != acc {
+		t.Errorf("expected to retrieve the installed accumulator")
+	}
+}


### PR DESCRIPTION
Fixes #276.

## Problem

\`OpenAIClient.GenerateWithToolsDetailed\` had a TODO and returned \`Usage: nil\` for any tool invocation:

\`\`\`go
return &interfaces.LLMResponse{
    ...
    Usage: nil, // TODO: Implement token usage tracking for tool iterations
\`\`\`

So \`agent.RunDetailed\` reported \`total_tokens: 0\` whenever tools were configured. This is **not** MCP-specific — it affects any agent with any tools. The reporter just hit it via MCP. The reporter also confirmed \`agent-token-usage-simple\` (no tools) works, which matches.

## Fix

\`pkg/llm/openai/usage_accumulator.go\`: a small mutex-guarded accumulator stashed in the request context.

\`GenerateWithTools\`'s two API call sites — the iteration loop and the final summary call — each push their \`resp.Usage\` (input/output/total/reasoning) into the accumulator if one is present.

\`GenerateWithToolsDetailed\` installs the accumulator before delegating, then snapshots the running total to populate \`LLMResponse.Usage\` with the real aggregated counts.

This avoids:
- A breaking signature change to \`GenerateWithTools\` (still \`(string, error)\`)
- A 500-line refactor of the existing tool-loop method
- Any change for callers that don't need detailed usage (\`GenerateWithTools\` paths just don't install an accumulator)

## Test plan

- New \`usage_accumulator_test.go\` covers per-call accumulation, untouched-returns-nil, and the context roundtrip
- \`go test ./pkg/llm/openai/...\` passes
- \`go test ./...\` passes

## Follow-up

Same TODO exists in Anthropic, Gemini, Azure OpenAI, vLLM detailed paths — worth a separate sweep with the same accumulator pattern.