### PR TITLE
Use OpenAI Responses API for reasoning tool calls

### DIFF
--- a/pkg/interfaces/llm.go
+++ b/pkg/interfaces/llm.go
@@ -37,6 +37,16 @@ type GenerateOptions struct {
 	Memory              Memory          // Optional memory for storing tool calls and results
 	StreamConfig        *StreamConfig   // Optional streaming configuration
 	CacheConfig         *CacheConfig    // Optional prompt caching configuration (Anthropic only)
+	FileInputs          []FileInput     // Optional file inputs for providers that support them
+}
+
+// FileInput describes a file passed directly to the model input.
+// Exactly one of FileID, FileURL, or FileData should be set.
+type FileInput struct {
+	FileID   string
+	FileURL  string
+	FileData string
+	Filename string
 }
 
 // CacheConfig contains configuration for prompt caching (Anthropic only)

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -147,6 +147,9 @@ func (c *OpenAIClient) generateInternal(ctx context.Context, prompt string, opti
 	for _, option := range options {
 		option(params)
 	}
+	if c.shouldUseResponsesAPI(params, nil) {
+		return c.generateWithResponsesAPI(ctx, prompt, nil, params)
+	}
 
 	// Get organization ID from context if available
 	orgID, _ := multitenancy.GetOrgID(ctx)
@@ -414,6 +417,13 @@ func (c *OpenAIClient) GenerateWithTools(ctx context.Context, prompt string, too
 			FrequencyPenalty: 0.0,
 			PresencePenalty:  0.0,
 		}
+	}
+	if c.shouldUseResponsesAPI(params, tools) {
+		response, err := c.generateWithResponsesAPI(ctx, prompt, tools, params)
+		if err != nil {
+			return "", err
+		}
+		return response.Content, nil
 	}
 
 	// Set default max iterations if not provided

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -35,6 +36,7 @@ type OpenAIClient struct {
 	baseURL         string
 	logger          logging.Logger
 	retryExecutor   *retry.Executor
+	useResponsesAPI bool
 }
 
 // Option represents an option for configuring the OpenAI client
@@ -102,6 +104,15 @@ func WithBaseURL(baseURL string) Option {
 		c.Client = openai.NewClient(option.WithAPIKey(c.apiKey), option.WithBaseURL(baseURL))
 		c.ChatService = openai.NewChatService(option.WithAPIKey(c.apiKey), option.WithBaseURL(baseURL))
 		c.ResponseService = openai.NewClient(option.WithAPIKey(c.apiKey), option.WithBaseURL(baseURL))
+	}
+}
+
+// WithResponsesAPI routes Generate and GenerateWithTools calls through OpenAI's
+// Responses API. It is opt-in so existing Chat Completions users keep the same
+// behavior unless they explicitly enable it.
+func WithResponsesAPI(enabled bool) Option {
+	return func(c *OpenAIClient) {
+		c.useResponsesAPI = enabled
 	}
 }
 
@@ -1097,6 +1108,38 @@ func WithReasoning(reasoning string) interfaces.GenerateOption {
 			options.LLMConfig = &interfaces.LLMConfig{}
 		}
 		options.LLMConfig.Reasoning = reasoning
+	}
+}
+
+// WithFileID attaches an already-uploaded OpenAI file to the model input.
+func WithFileID(fileID string) interfaces.GenerateOption {
+	return func(options *interfaces.GenerateOptions) {
+		options.FileInputs = append(options.FileInputs, interfaces.FileInput{FileID: fileID})
+	}
+}
+
+// WithFileURL attaches an externally reachable file URL to the model input.
+// OpenAI supports file URLs through the Responses API.
+func WithFileURL(fileURL string) interfaces.GenerateOption {
+	return func(options *interfaces.GenerateOptions) {
+		options.FileInputs = append(options.FileInputs, interfaces.FileInput{FileURL: fileURL})
+	}
+}
+
+// WithFileData attaches inline file bytes to the model input as a data URL.
+func WithFileData(filename, mimeType string, data []byte) interfaces.GenerateOption {
+	return func(options *interfaces.GenerateOptions) {
+		if mimeType == "" {
+			mimeType = "application/octet-stream"
+		}
+		options.FileInputs = append(options.FileInputs, interfaces.FileInput{
+			Filename: filename,
+			FileData: fmt.Sprintf(
+				"data:%s;base64,%s",
+				mimeType,
+				base64.StdEncoding.EncodeToString(data),
+			),
+		})
 	}
 }
 

--- a/pkg/llm/openai/client_test.go
+++ b/pkg/llm/openai/client_test.go
@@ -588,6 +588,100 @@ func TestReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestReasoningModelUsesResponsesAPIWithToolsAndStructuredOutput(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.URL.Path != "/responses" {
+			t.Fatalf("expected /responses endpoint, got %s", r.URL.Path)
+		}
+
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+
+		if requestCount == 1 {
+			reasoning := reqBody["reasoning"].(map[string]interface{})
+			if reasoning["effort"] != "low" {
+				t.Fatalf("expected reasoning effort low, got %v", reasoning["effort"])
+			}
+
+			tools := reqBody["tools"].([]interface{})
+			if len(tools) != 1 || tools[0].(map[string]interface{})["type"] != "function" {
+				t.Fatalf("expected function tool in request, got %v", tools)
+			}
+
+			text := reqBody["text"].(map[string]interface{})
+			format := text["format"].(map[string]interface{})
+			if format["type"] != "json_schema" || format["name"] != "answer" {
+				t.Fatalf("expected json_schema response format, got %v", format)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"id":"resp_1",
+				"object":"response",
+				"created_at":0,
+				"model":"gpt-5-mini",
+				"status":"completed",
+				"output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"test_tool_1","arguments":"{\"param\":\"x\"}","status":"completed"}],
+				"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"output_tokens_details":{"reasoning_tokens":1}}
+			}`))
+			return
+		}
+
+		input := reqBody["input"].([]interface{})
+		lastInput := input[len(input)-1].(map[string]interface{})
+		if lastInput["type"] != "function_call_output" || lastInput["call_id"] != "call_1" {
+			t.Fatalf("expected function_call_output for second request, got %v", lastInput)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"resp_2",
+			"object":"response",
+			"created_at":0,
+			"model":"gpt-5-mini",
+			"status":"completed",
+			"output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"{\"answer\":\"ok\"}","annotations":[]}]}],
+			"usage":{"input_tokens":4,"output_tokens":5,"total_tokens":9,"output_tokens_details":{"reasoning_tokens":2}}
+		}`))
+	}))
+	defer server.Close()
+
+	client := openai_client.NewClient("test-key",
+		openai_client.WithBaseURL(server.URL),
+		openai_client.WithModel("gpt-5-mini"),
+		openai_client.WithLogger(logging.New()),
+	)
+
+	format := interfaces.ResponseFormat{
+		Type: interfaces.ResponseFormatJSON,
+		Name: "answer",
+		Schema: interfaces.JSONSchema{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"answer": map[string]interface{}{"type": "string"},
+			},
+			"required": []string{"answer"},
+		},
+	}
+
+	resp, err := client.GenerateWithTools(context.Background(), "test", []interfaces.Tool{
+		&mockTool{name: "test_tool_1", description: "Test tool 1"},
+	}, openai_client.WithReasoning("low"), openai_client.WithResponseFormat(format))
+	if err != nil {
+		t.Fatalf("GenerateWithTools failed: %v", err)
+	}
+	if resp != `{"answer":"ok"}` {
+		t.Fatalf("expected structured response, got %s", resp)
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected 2 responses requests, got %d", requestCount)
+	}
+}
+
 // mockMemory is a simple in-memory implementation for testing
 type mockMemory struct {
 	messages []interfaces.Message

--- a/pkg/llm/openai/client_test.go
+++ b/pkg/llm/openai/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
@@ -653,6 +654,7 @@ func TestReasoningModelUsesResponsesAPIWithToolsAndStructuredOutput(t *testing.T
 	client := openai_client.NewClient("test-key",
 		openai_client.WithBaseURL(server.URL),
 		openai_client.WithModel("gpt-5-mini"),
+		openai_client.WithResponsesAPI(true),
 		openai_client.WithLogger(logging.New()),
 	)
 
@@ -679,6 +681,141 @@ func TestReasoningModelUsesResponsesAPIWithToolsAndStructuredOutput(t *testing.T
 	}
 	if requestCount != 2 {
 		t.Fatalf("expected 2 responses requests, got %d", requestCount)
+	}
+}
+
+func TestResponsesAPIIsOptInForExistingFlows(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/responses" {
+			t.Fatalf("did not expect default request to use /responses")
+		}
+		if r.URL.Path != "/chat/completions" {
+			t.Fatalf("expected /chat/completions endpoint, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(openai.ChatCompletion{
+			Choices: []openai.ChatCompletionChoice{{Message: openai.ChatCompletionMessage{Content: `{"answer":"ok"}`, Role: "assistant"}}},
+		})
+	}))
+	defer server.Close()
+
+	client := openai_client.NewClient("test-key",
+		openai_client.WithBaseURL(server.URL),
+		openai_client.WithModel("gpt-5-mini"),
+		openai_client.WithLogger(logging.New()),
+	)
+
+	format := interfaces.ResponseFormat{
+		Type:   interfaces.ResponseFormatJSON,
+		Name:   "answer",
+		Schema: interfaces.JSONSchema{"type": "object"},
+	}
+
+	resp, err := client.GenerateWithTools(context.Background(), "test", []interfaces.Tool{
+		&mockTool{name: "test_tool_1", description: "Test tool 1"},
+	}, openai_client.WithReasoning("low"), openai_client.WithResponseFormat(format))
+	if err != nil {
+		t.Fatalf("GenerateWithTools failed: %v", err)
+	}
+	if resp != `{"answer":"ok"}` {
+		t.Fatalf("expected chat completion response, got %s", resp)
+	}
+}
+
+func TestFileInputsUseResponsesAPI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Fatalf("expected /responses endpoint, got %s", r.URL.Path)
+		}
+
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+
+		input := reqBody["input"].([]interface{})
+		message := input[0].(map[string]interface{})
+		content := message["content"].([]interface{})
+		if content[0].(map[string]interface{})["type"] != "input_text" {
+			t.Fatalf("expected input_text first, got %v", content[0])
+		}
+		fileByID := content[1].(map[string]interface{})
+		if fileByID["type"] != "input_file" || fileByID["file_id"] != "file_123" {
+			t.Fatalf("expected file_id input_file, got %v", fileByID)
+		}
+		fileByURL := content[2].(map[string]interface{})
+		if fileByURL["type"] != "input_file" || fileByURL["file_url"] != "https://example.com/report.pdf" {
+			t.Fatalf("expected file_url input_file, got %v", fileByURL)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"resp_1",
+			"object":"response",
+			"created_at":0,
+			"model":"gpt-4o-mini",
+			"status":"completed",
+			"output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"done","annotations":[]}]}],
+			"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}
+		}`))
+	}))
+	defer server.Close()
+
+	client := openai_client.NewClient("test-key",
+		openai_client.WithBaseURL(server.URL),
+		openai_client.WithModel("gpt-4o-mini"),
+		openai_client.WithLogger(logging.New()),
+	)
+
+	resp, err := client.Generate(context.Background(), "Summarize these files.",
+		openai_client.WithFileID("file_123"),
+		openai_client.WithFileURL("https://example.com/report.pdf"),
+	)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if resp != "done" {
+		t.Fatalf("expected response, got %s", resp)
+	}
+}
+
+func TestUploadUserData(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/files" {
+			t.Fatalf("expected /files endpoint, got %s", r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1024); err != nil {
+			t.Fatalf("failed to parse multipart form: %v", err)
+		}
+		if r.FormValue("purpose") != "user_data" {
+			t.Fatalf("expected purpose user_data, got %s", r.FormValue("purpose"))
+		}
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("expected file form field: %v", err)
+		}
+		defer file.Close()
+		if header.Filename != "notes.txt" {
+			t.Fatalf("expected filename notes.txt, got %s", header.Filename)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"file_123","object":"file","bytes":5,"created_at":0,"filename":"notes.txt","purpose":"user_data","status":"processed"}`))
+	}))
+	defer server.Close()
+
+	client := openai_client.NewClient("test-key",
+		openai_client.WithBaseURL(server.URL),
+		openai_client.WithLogger(logging.New()),
+	)
+
+	fileID, err := client.UploadUserData(context.Background(), strings.NewReader("hello"), "notes.txt", "text/plain")
+	if err != nil {
+		t.Fatalf("UploadUserData failed: %v", err)
+	}
+	if fileID != "file_123" {
+		t.Fatalf("expected file_123, got %s", fileID)
 	}
 }
 

--- a/pkg/llm/openai/client_test.go
+++ b/pkg/llm/openai/client_test.go
@@ -748,6 +748,10 @@ func TestFileInputsUseResponsesAPI(t *testing.T) {
 		if fileByURL["type"] != "input_file" || fileByURL["file_url"] != "https://example.com/report.pdf" {
 			t.Fatalf("expected file_url input_file, got %v", fileByURL)
 		}
+		fileData := content[3].(map[string]interface{})
+		if fileData["type"] != "input_file" || fileData["filename"] != "notes.txt" || !strings.HasPrefix(fileData["file_data"].(string), "data:text/plain;base64,") {
+			t.Fatalf("expected file_data input_file, got %v", fileData)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -771,6 +775,7 @@ func TestFileInputsUseResponsesAPI(t *testing.T) {
 	resp, err := client.Generate(context.Background(), "Summarize these files.",
 		openai_client.WithFileID("file_123"),
 		openai_client.WithFileURL("https://example.com/report.pdf"),
+		openai_client.WithFileData("notes.txt", "text/plain", []byte("hello")),
 	)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
@@ -817,6 +822,77 @@ func TestUploadUserData(t *testing.T) {
 	if fileID != "file_123" {
 		t.Fatalf("expected file_123, got %s", fileID)
 	}
+}
+
+func TestResponsesAPIValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		client  *openai_client.OpenAIClient
+		options []interfaces.GenerateOption
+		wantErr string
+	}{
+		{
+			name:   "file input requires exactly one source",
+			client: openai_client.NewClient("test-key", openai_client.WithModel("gpt-4o-mini")),
+			options: []interfaces.GenerateOption{
+				func(options *interfaces.GenerateOptions) {
+					options.FileInputs = append(options.FileInputs, interfaces.FileInput{FileID: "file_123", FileURL: "https://example.com/report.pdf"})
+				},
+			},
+			wantErr: "exactly one of FileID, FileURL, or FileData",
+		},
+		{
+			name:   "file data requires filename",
+			client: openai_client.NewClient("test-key", openai_client.WithModel("gpt-4o-mini")),
+			options: []interfaces.GenerateOption{
+				openai_client.WithFileData("", "text/plain", []byte("hello")),
+			},
+			wantErr: "with FileData requires Filename",
+		},
+		{
+			name:   "responses api rejects unsupported stop sequences",
+			client: openai_client.NewClient("test-key", openai_client.WithResponsesAPI(true)),
+			options: []interfaces.GenerateOption{
+				openai_client.WithStopSequences([]string{"END"}),
+			},
+			wantErr: "does not support stop_sequences",
+		},
+		{
+			name:   "responses api rejects memory",
+			client: openai_client.NewClient("test-key", openai_client.WithResponsesAPI(true)),
+			options: []interfaces.GenerateOption{
+				interfaces.WithMemory(&mockMemory{}),
+			},
+			wantErr: "does not support memory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.client.Generate(context.Background(), "test", tt.options...)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestStreamingValidationErrors(t *testing.T) {
+	t.Run("responses api streaming is explicit error", func(t *testing.T) {
+		client := openai_client.NewClient("test-key", openai_client.WithResponsesAPI(true))
+		_, err := client.GenerateStream(context.Background(), "test")
+		if err == nil || !strings.Contains(err.Error(), "responses api streaming is not supported") {
+			t.Fatalf("expected responses streaming error, got %v", err)
+		}
+	})
+
+	t.Run("file inputs are not silently ignored in streaming", func(t *testing.T) {
+		client := openai_client.NewClient("test-key")
+		_, err := client.GenerateStream(context.Background(), "test", openai_client.WithFileID("file_123"))
+		if err == nil || !strings.Contains(err.Error(), "file inputs are not supported with streaming") {
+			t.Fatalf("expected file input streaming error, got %v", err)
+		}
+	})
 }
 
 // mockMemory is a simple in-memory implementation for testing

--- a/pkg/llm/openai/files.go
+++ b/pkg/llm/openai/files.go
@@ -1,0 +1,37 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	openaiapi "github.com/openai/openai-go/v2"
+)
+
+// UploadUserDataFile uploads a local file for later use as a model input and
+// returns the OpenAI file ID.
+func (c *OpenAIClient) UploadUserDataFile(ctx context.Context, path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	return c.UploadUserData(ctx, file, filepath.Base(path), "")
+}
+
+// UploadUserData uploads file content for later use as a model input and returns
+// the OpenAI file ID.
+func (c *OpenAIClient) UploadUserData(ctx context.Context, reader io.Reader, filename, contentType string) (string, error) {
+	file, err := c.Client.Files.New(ctx, openaiapi.FileNewParams{
+		File:    openaiapi.File(reader, filename, contentType),
+		Purpose: openaiapi.FilePurposeUserData,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to upload file: %w", err)
+	}
+
+	return file.ID, nil
+}

--- a/pkg/llm/openai/responses.go
+++ b/pkg/llm/openai/responses.go
@@ -14,7 +14,10 @@ import (
 )
 
 func (c *OpenAIClient) shouldUseResponsesAPI(params *interfaces.GenerateOptions, tools []interfaces.Tool) bool {
-	return isReasoningModel(c.Model) && (len(tools) > 0 || params.ResponseFormat != nil)
+	if params != nil && len(params.FileInputs) > 0 {
+		return true
+	}
+	return c.useResponsesAPI
 }
 
 func (c *OpenAIClient) generateWithResponsesAPI(ctx context.Context, prompt string, tools []interfaces.Tool, params *interfaces.GenerateOptions) (*interfaces.LLMResponse, error) {
@@ -84,7 +87,7 @@ func (c *OpenAIClient) newResponseRequest(prompt string, params *interfaces.Gene
 	if params.SystemMessage != "" {
 		input = append(input, responses.ResponseInputItemUnionParam{OfMessage: responseMessage("system", params.SystemMessage)})
 	}
-	input = append(input, responses.ResponseInputItemUnionParam{OfMessage: responseMessage("user", prompt)})
+	input = append(input, responses.ResponseInputItemUnionParam{OfMessage: responseUserMessage(prompt, params.FileInputs)})
 
 	req := responses.ResponseNewParams{
 		Input: responses.ResponseNewParamsInputUnion{OfInputItemList: input},
@@ -120,6 +123,39 @@ func responseMessage(role, content string) *responses.EasyInputMessageParam {
 		Role: responses.EasyInputMessageRole(role),
 		Content: responses.EasyInputMessageContentUnionParam{
 			OfString: param.NewOpt(content),
+		},
+	}
+}
+
+func responseUserMessage(prompt string, files []interfaces.FileInput) *responses.EasyInputMessageParam {
+	if len(files) == 0 {
+		return responseMessage("user", prompt)
+	}
+
+	content := responses.ResponseInputMessageContentListParam{
+		responses.ResponseInputContentUnionParam{OfInputText: &responses.ResponseInputTextParam{Text: prompt}},
+	}
+	for _, file := range files {
+		inputFile := responses.ResponseInputFileParam{}
+		if file.FileID != "" {
+			inputFile.FileID = param.NewOpt(file.FileID)
+		}
+		if file.FileURL != "" {
+			inputFile.FileURL = param.NewOpt(file.FileURL)
+		}
+		if file.FileData != "" {
+			inputFile.FileData = param.NewOpt(file.FileData)
+		}
+		if file.Filename != "" {
+			inputFile.Filename = param.NewOpt(file.Filename)
+		}
+		content = append(content, responses.ResponseInputContentUnionParam{OfInputFile: &inputFile})
+	}
+
+	return &responses.EasyInputMessageParam{
+		Role: responses.EasyInputMessageRoleUser,
+		Content: responses.EasyInputMessageContentUnionParam{
+			OfInputItemContentList: content,
 		},
 	}
 }

--- a/pkg/llm/openai/responses.go
+++ b/pkg/llm/openai/responses.go
@@ -1,0 +1,252 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/Ingenimax/agent-sdk-go/pkg/tracing"
+	"github.com/openai/openai-go/v2/packages/param"
+	"github.com/openai/openai-go/v2/responses"
+	"github.com/openai/openai-go/v2/shared"
+)
+
+func (c *OpenAIClient) shouldUseResponsesAPI(params *interfaces.GenerateOptions, tools []interfaces.Tool) bool {
+	return isReasoningModel(c.Model) && (len(tools) > 0 || params.ResponseFormat != nil)
+}
+
+func (c *OpenAIClient) generateWithResponsesAPI(ctx context.Context, prompt string, tools []interfaces.Tool, params *interfaces.GenerateOptions) (*interfaces.LLMResponse, error) {
+	req := c.newResponseRequest(prompt, params)
+	if len(tools) > 0 {
+		req.Tools = buildResponseTools(tools)
+		req.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsAuto)}
+		req.ParallelToolCalls = param.NewOpt(true)
+	}
+
+	maxIterations := params.MaxIterations
+	if maxIterations == 0 {
+		maxIterations = 2
+	}
+
+	input := req.Input.OfInputItemList
+	var lastResp *responses.Response
+	for iteration := 0; iteration < maxIterations; iteration++ {
+		req.Input.OfInputItemList = input
+		resp, err := c.Client.Responses.New(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create response: %w", err)
+		}
+		lastResp = resp
+		addResponseUsage(ctx, resp, c.Model)
+
+		toolCalls := responseFunctionCalls(resp)
+		if len(toolCalls) == 0 {
+			return llmResponseFromOpenAIResponse(resp, c.Model), nil
+		}
+
+		for _, toolCall := range toolCalls {
+			input = append(input, responses.ResponseInputItemUnionParam{OfFunctionCall: &responses.ResponseFunctionToolCallParam{
+				ID:        param.NewOpt(toolCall.ID),
+				CallID:    toolCall.CallID,
+				Name:      toolCall.Name,
+				Arguments: toolCall.Arguments,
+				Status:    responses.ResponseFunctionToolCallStatusCompleted,
+			}})
+
+			result := c.executeResponseToolCall(ctx, tools, toolCall, params)
+			input = append(input, responses.ResponseInputItemUnionParam{OfFunctionCallOutput: &responses.ResponseInputItemFunctionCallOutputParam{
+				CallID: toolCall.CallID,
+				Output: result,
+			}})
+		}
+	}
+
+	if params.DisableFinalSummary && lastResp != nil {
+		return llmResponseFromOpenAIResponse(lastResp, c.Model), nil
+	}
+
+	input = append(input, responses.ResponseInputItemUnionParam{OfMessage: responseMessage("user", "Please provide your final response based on the information available. Do not request any additional tools.")})
+	req.Input.OfInputItemList = input
+	req.Tools = nil
+	req.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{}
+	finalResp, err := c.Client.Responses.New(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create final response: %w", err)
+	}
+	addResponseUsage(ctx, finalResp, c.Model)
+	return llmResponseFromOpenAIResponse(finalResp, c.Model), nil
+}
+
+func (c *OpenAIClient) newResponseRequest(prompt string, params *interfaces.GenerateOptions) responses.ResponseNewParams {
+	input := responses.ResponseInputParam{}
+	if params.SystemMessage != "" {
+		input = append(input, responses.ResponseInputItemUnionParam{OfMessage: responseMessage("system", params.SystemMessage)})
+	}
+	input = append(input, responses.ResponseInputItemUnionParam{OfMessage: responseMessage("user", prompt)})
+
+	req := responses.ResponseNewParams{
+		Input: responses.ResponseNewParamsInputUnion{OfInputItemList: input},
+		Model: shared.ResponsesModel(c.Model),
+		Store: param.NewOpt(false),
+	}
+
+	if params.LLMConfig != nil {
+		if !isReasoningModel(c.Model) {
+			req.Temperature = param.NewOpt(params.LLMConfig.Temperature)
+			if params.LLMConfig.TopP > 0 && params.LLMConfig.TopP <= 1 {
+				req.TopP = param.NewOpt(params.LLMConfig.TopP)
+			}
+		}
+		if params.LLMConfig.Reasoning != "" {
+			req.Reasoning = shared.ReasoningParam{Effort: shared.ReasoningEffort(params.LLMConfig.Reasoning)}
+		}
+	}
+
+	if params.ResponseFormat != nil {
+		req.Text.Format = responses.ResponseFormatTextConfigUnionParam{OfJSONSchema: &responses.ResponseFormatTextJSONSchemaConfigParam{
+			Name:   params.ResponseFormat.Name,
+			Schema: map[string]any(params.ResponseFormat.Schema),
+			Strict: param.NewOpt(true),
+		}}
+	}
+
+	return req
+}
+
+func responseMessage(role, content string) *responses.EasyInputMessageParam {
+	return &responses.EasyInputMessageParam{
+		Role: responses.EasyInputMessageRole(role),
+		Content: responses.EasyInputMessageContentUnionParam{
+			OfString: param.NewOpt(content),
+		},
+	}
+}
+
+func buildResponseTools(tools []interfaces.Tool) []responses.ToolUnionParam {
+	openaiTools := make([]responses.ToolUnionParam, len(tools))
+	for i, tool := range tools {
+		properties := make(map[string]any)
+		required := []string{}
+		for name, paramSpec := range tool.Parameters() {
+			property := map[string]any{
+				"type":        paramSpec.Type,
+				"description": paramSpec.Description,
+			}
+			if paramSpec.Default != nil {
+				property["default"] = paramSpec.Default
+			}
+			if paramSpec.Items != nil {
+				items := map[string]any{"type": paramSpec.Items.Type}
+				if paramSpec.Items.Enum != nil {
+					items["enum"] = paramSpec.Items.Enum
+				}
+				property["items"] = items
+			}
+			if paramSpec.Enum != nil {
+				property["enum"] = paramSpec.Enum
+			}
+			properties[name] = property
+			if paramSpec.Required {
+				required = append(required, name)
+			}
+		}
+
+		openaiTools[i] = responses.ToolParamOfFunction(tool.Name(), map[string]any{
+			"type":       "object",
+			"properties": properties,
+			"required":   required,
+		}, true)
+		openaiTools[i].OfFunction.Description = param.NewOpt(tool.Description())
+	}
+	return openaiTools
+}
+
+func responseFunctionCalls(resp *responses.Response) []responses.ResponseFunctionToolCall {
+	toolCalls := []responses.ResponseFunctionToolCall{}
+	for _, item := range resp.Output {
+		if item.Type == "function_call" {
+			toolCalls = append(toolCalls, item.AsFunctionCall())
+		}
+	}
+	return toolCalls
+}
+
+func (c *OpenAIClient) executeResponseToolCall(ctx context.Context, tools []interfaces.Tool, toolCall responses.ResponseFunctionToolCall, params *interfaces.GenerateOptions) string {
+	var selectedTool interfaces.Tool
+	for _, tool := range tools {
+		if tool.Name() == toolCall.Name {
+			selectedTool = tool
+			break
+		}
+	}
+
+	start := time.Now()
+	trace := tracing.ToolCall{
+		Name:      toolCall.Name,
+		Arguments: toolCall.Arguments,
+		ID:        toolCall.CallID,
+		Timestamp: start.Format(time.RFC3339),
+		StartTime: start,
+	}
+
+	if selectedTool == nil {
+		result := fmt.Sprintf("Error: tool not found: %s", toolCall.Name)
+		trace.Error = result
+		trace.Result = result
+		tracing.AddToolCallToContext(ctx, trace)
+		return result
+	}
+
+	result, err := selectedTool.Execute(ctx, toolCall.Arguments)
+	trace.Duration = time.Since(start)
+	trace.DurationMs = trace.Duration.Milliseconds()
+	if err != nil {
+		result = fmt.Sprintf("Error: %v", err)
+		trace.Error = err.Error()
+	}
+	trace.Result = result
+	tracing.AddToolCallToContext(ctx, trace)
+
+	if params.Memory != nil {
+		_ = params.Memory.AddMessage(ctx, interfaces.Message{Role: "assistant", Content: "", ToolCalls: []interfaces.ToolCall{{ID: toolCall.CallID, Name: toolCall.Name, Arguments: toolCall.Arguments}}})
+		_ = params.Memory.AddMessage(ctx, interfaces.Message{Role: "tool", Content: result, ToolCallID: toolCall.CallID, Metadata: map[string]interface{}{"tool_name": toolCall.Name}})
+	}
+
+	return result
+}
+
+func llmResponseFromOpenAIResponse(resp *responses.Response, fallbackModel string) *interfaces.LLMResponse {
+	model := string(resp.Model)
+	if model == "" {
+		model = fallbackModel
+	}
+	return &interfaces.LLMResponse{
+		Content:    strings.TrimSpace(resp.OutputText()),
+		Model:      model,
+		StopReason: string(resp.Status),
+		Usage: &interfaces.TokenUsage{
+			InputTokens:     int(resp.Usage.InputTokens),
+			OutputTokens:    int(resp.Usage.OutputTokens),
+			TotalTokens:     int(resp.Usage.TotalTokens),
+			ReasoningTokens: int(resp.Usage.OutputTokensDetails.ReasoningTokens),
+		},
+		Metadata: map[string]interface{}{
+			"provider": "openai",
+			"endpoint": "responses",
+		},
+	}
+}
+
+func addResponseUsage(ctx context.Context, resp *responses.Response, model string) {
+	if acc := getUsageAccumulator(ctx); acc != nil {
+		acc.add(
+			int(resp.Usage.InputTokens),
+			int(resp.Usage.OutputTokens),
+			int(resp.Usage.TotalTokens),
+			int(resp.Usage.OutputTokensDetails.ReasoningTokens),
+			model,
+		)
+	}
+}

--- a/pkg/llm/openai/responses.go
+++ b/pkg/llm/openai/responses.go
@@ -13,14 +13,84 @@ import (
 	"github.com/openai/openai-go/v2/shared"
 )
 
-func (c *OpenAIClient) shouldUseResponsesAPI(params *interfaces.GenerateOptions, tools []interfaces.Tool) bool {
+func (c *OpenAIClient) shouldUseResponsesAPI(params *interfaces.GenerateOptions, _ []interfaces.Tool) bool {
 	if params != nil && len(params.FileInputs) > 0 {
 		return true
 	}
 	return c.useResponsesAPI
 }
 
+func validateResponsesAPIOptions(params *interfaces.GenerateOptions) error {
+	if params == nil {
+		return nil
+	}
+
+	if params.Memory != nil {
+		return fmt.Errorf("openai responses api does not support memory in this SDK path yet; remove WithMemory or disable WithResponsesAPI")
+	}
+
+	if params.ResponseFormat != nil {
+		if params.ResponseFormat.Name == "" {
+			return fmt.Errorf("openai responses api response format requires a non-empty name")
+		}
+		if len(params.ResponseFormat.Schema) == 0 {
+			return fmt.Errorf("openai responses api response format requires a non-empty schema")
+		}
+	}
+
+	if params.LLMConfig != nil {
+		unsupported := []string{}
+		if params.LLMConfig.FrequencyPenalty != 0 {
+			unsupported = append(unsupported, "frequency_penalty")
+		}
+		if params.LLMConfig.PresencePenalty != 0 {
+			unsupported = append(unsupported, "presence_penalty")
+		}
+		if len(params.LLMConfig.StopSequences) > 0 {
+			unsupported = append(unsupported, "stop_sequences")
+		}
+		if len(unsupported) > 0 {
+			return fmt.Errorf("openai responses api does not support %s in this SDK path", strings.Join(unsupported, ", "))
+		}
+	}
+
+	for i, file := range params.FileInputs {
+		sources := 0
+		if file.FileID != "" {
+			sources++
+		}
+		if file.FileURL != "" {
+			sources++
+		}
+		if file.FileData != "" {
+			sources++
+		}
+		if sources != 1 {
+			return fmt.Errorf("openai file input %d must set exactly one of FileID, FileURL, or FileData", i)
+		}
+		if file.FileData != "" && file.Filename == "" {
+			return fmt.Errorf("openai file input %d with FileData requires Filename", i)
+		}
+	}
+
+	return nil
+}
+
+func validateOpenAIStreamingOptions(params *interfaces.GenerateOptions, useResponsesAPI bool) error {
+	if useResponsesAPI {
+		return fmt.Errorf("openai responses api streaming is not supported in this SDK path yet; use Generate or disable WithResponsesAPI")
+	}
+	if params != nil && len(params.FileInputs) > 0 {
+		return fmt.Errorf("openai file inputs are not supported with streaming; use Generate or GenerateWithTools")
+	}
+	return nil
+}
+
 func (c *OpenAIClient) generateWithResponsesAPI(ctx context.Context, prompt string, tools []interfaces.Tool, params *interfaces.GenerateOptions) (*interfaces.LLMResponse, error) {
+	if err := validateResponsesAPIOptions(params); err != nil {
+		return nil, err
+	}
+
 	req := c.newResponseRequest(prompt, params)
 	if len(tools) > 0 {
 		req.Tools = buildResponseTools(tools)

--- a/pkg/llm/openai/streaming.go
+++ b/pkg/llm/openai/streaming.go
@@ -28,6 +28,9 @@ func (c *OpenAIClient) GenerateStream(
 	for _, option := range options {
 		option(params)
 	}
+	if err := validateOpenAIStreamingOptions(params, c.useResponsesAPI); err != nil {
+		return nil, err
+	}
 
 	// Check for organization ID in context
 	defaultOrgID := "default"
@@ -269,6 +272,9 @@ func (c *OpenAIClient) GenerateWithToolsStream(
 
 	for _, option := range options {
 		option(params)
+	}
+	if err := validateOpenAIStreamingOptions(params, c.useResponsesAPI); err != nil {
+		return nil, err
 	}
 
 	// Set default max iterations if not provided


### PR DESCRIPTION
## Summary
- Add opt-in OpenAI Responses API support via `openai.WithResponsesAPI(true)` so existing Chat Completions users keep current behavior by default.
- Support reasoning effort, function tools, and JSON schema response format together on the Responses API path.
- Add OpenAI file input support with `WithFileID`, `WithFileURL`, `WithFileData`, plus `UploadUserData` helpers using file purpose `user_data`.
- Automatically use Responses API when file inputs are provided, because file URLs and `input_file` content require Responses API support.
- Add early validation for incompatible Responses/file usage, including malformed file inputs, unsupported chat-only params, memory on the Responses path, and streaming/file-input misuse.

## Validation
- `go test ./pkg/llm/openai`
- `make test`
- `make lint` could not run because `golangci-lint` is not installed in this environment.