### PR TITLE
feat: add HTTP MCP test agent and fix Token/HttpTransportMode propagation

### DIFF
--- a/examples/mcp/http-test-agent/README.md
+++ b/examples/mcp/http-test-agent/README.md
@@ -1,0 +1,34 @@
+# HTTP MCP Test Agent
+
+Minimal agent that connects to a single MCP server over HTTP (with token in the URL) for testing.
+
+## Prerequisites
+
+- `OPEN_API_URL`
+- `OPENAI_API_KEY` set in the environment
+- MCP server reachable at `http://localhost:8000/mcp` (e.g. on same host or Docker network)
+
+## Run
+
+```bash
+cd examples/mcp/http-test-agent
+go run .
+```
+
+With a custom query:
+
+```bash
+go run . "Your question here"
+```
+
+## Configuration
+
+The MCP server URL (including token) is set in `main.go` as `mcpServerURL`. Change it or load from env if needed:
+
+```go
+mcpURL := os.Getenv("MCP_SERVER_URL")
+if mcpURL == "" {
+    mcpURL = mcpServerURL
+}
+agent.WithMCPURLs(mcpURL),
+```

--- a/examples/mcp/http-test-agent/main.go
+++ b/examples/mcp/http-test-agent/main.go
@@ -1,0 +1,56 @@
+// Simple agent that connects to an MCP server over HTTP for testing.
+// Set OPENAI_API_KEY and ensure the MCP server at the URL is reachable.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/agent"
+	"github.com/Ingenimax/agent-sdk-go/pkg/llm/openai"
+	"github.com/Ingenimax/agent-sdk-go/pkg/memory"
+	"github.com/Ingenimax/agent-sdk-go/pkg/multitenancy"
+	"github.com/joho/godotenv"
+)
+
+// MCP server URL for testing (token in query string).
+
+func main() {
+	godotenv.Load()
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	baseURL := os.Getenv("OPENAI_BASE_URL")
+	mcpServerURL := os.Getenv("MCP_SERVER_URL")
+
+	llm := openai.NewClient(apiKey,
+		openai.WithModel("gemini-2.5-flash"),
+		openai.WithBaseURL(baseURL),
+	)
+
+	myAgent, err := agent.NewAgent(
+		agent.WithLLM(llm),
+		agent.WithMemory(memory.NewConversationBuffer()),
+		agent.WithSystemPrompt("You are a helpful assistant with access to MCP tools. Use them when relevant."),
+		agent.WithMCPURLs(mcpServerURL),
+	)
+	if err != nil {
+		log.Fatalf("Failed to create agent: %v", err)
+	}
+
+	ctx := context.Background()
+	ctx = multitenancy.WithOrgID(ctx, "default-org")
+	ctx = context.WithValue(ctx, memory.ConversationIDKey, "mcp-test-conv")
+
+	query := "What tools do you have available? List them briefly."
+	if len(os.Args) > 1 {
+		query = os.Args[1]
+	}
+
+	fmt.Printf("Query: %s\n\n", query)
+	response, err := myAgent.Run(ctx, query)
+	if err != nil {
+		log.Fatalf("Run failed: %v", err)
+	}
+	fmt.Printf("Response: %s\n", response)
+}

--- a/examples/mcp/http-test-agent/main.go
+++ b/examples/mcp/http-test-agent/main.go
@@ -12,13 +12,9 @@ import (
 	"github.com/Ingenimax/agent-sdk-go/pkg/llm/openai"
 	"github.com/Ingenimax/agent-sdk-go/pkg/memory"
 	"github.com/Ingenimax/agent-sdk-go/pkg/multitenancy"
-	"github.com/joho/godotenv"
 )
 
-// MCP server URL for testing (token in query string).
-
 func main() {
-	godotenv.Load()
 	apiKey := os.Getenv("OPENAI_API_KEY")
 	baseURL := os.Getenv("OPENAI_BASE_URL")
 	mcpServerURL := os.Getenv("MCP_SERVER_URL")

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -506,13 +506,15 @@ func WithMCPURLs(urls ...string) Option {
 		// Convert mcp.LazyMCPServerConfig to agent.LazyMCPConfig
 		for _, config := range lazyConfigs {
 			agentConfig := LazyMCPConfig{
-				Name:         config.Name,
-				Type:         config.Type,
-				Command:      config.Command,
-				Args:         config.Args,
-				Env:          config.Env,
-				URL:          config.URL,
-				AllowedTools: config.AllowedTools,
+				Name:              config.Name,
+				Type:              config.Type,
+				Command:           config.Command,
+				Args:              config.Args,
+				Env:               config.Env,
+				URL:               config.URL,
+				Token:             config.Token,
+				HttpTransportMode: config.HttpTransportMode,
+				AllowedTools:      config.AllowedTools,
 			}
 			a.lazyMCPConfigs = append(a.lazyMCPConfigs, agentConfig)
 		}
@@ -542,13 +544,15 @@ func WithMCPPresets(presetNames ...string) Option {
 		// Convert mcp.LazyMCPServerConfig to agent.LazyMCPConfig
 		for _, config := range lazyConfigs {
 			agentConfig := LazyMCPConfig{
-				Name:         config.Name,
-				Type:         config.Type,
-				Command:      config.Command,
-				Args:         config.Args,
-				Env:          config.Env,
-				URL:          config.URL,
-				AllowedTools: config.AllowedTools,
+				Name:              config.Name,
+				Type:              config.Type,
+				Command:           config.Command,
+				Args:              config.Args,
+				Env:               config.Env,
+				URL:               config.URL,
+				Token:             config.Token,
+				HttpTransportMode: config.HttpTransportMode,
+				AllowedTools:      config.AllowedTools,
 			}
 			a.lazyMCPConfigs = append(a.lazyMCPConfigs, agentConfig)
 		}

--- a/pkg/mcp/README.md
+++ b/pkg/mcp/README.md
@@ -6,7 +6,7 @@ This package provides integration with the [Model Context Protocol (MCP)](https:
 
 The MCP integration allows agents to:
 
-1. Connect to MCP servers using different transports (stdio, HTTP)
+1. Connect to MCP servers using different transports (stdio, HTTP SSE, HTTP Streamable)
 2. List and use tools provided by MCP servers
 3. Convert MCP tools to agent tools
 
@@ -86,7 +86,20 @@ for _, tool := range tools {
 The MCP integration supports different transports for connecting to MCP servers:
 
 - **stdio**: For local MCP servers that communicate over standard input/output
-- **HTTP**: For remote MCP servers that communicate over HTTP
+- **HTTP**: For remote MCP servers (SSE or Streamable HTTP)
+
+### Simple URL format (WithMCPURLs / Builder.AddServer)
+
+HTTP server URLs can include optional query parameters:
+
+- **token** – Auth token (sent as header and query when calling the server)
+- **transport** – `sse` or `streamable` to force the transport; if omitted, the client tries SSE first then falls back to Streamable HTTP on failure
+
+Examples:
+
+- `http://localhost:8000/mcp?token=secret`
+- `https://api.example.com/mcp?token=xxx&transport=streamable`
+- `https://api.example.com/mcp?token=xxx&transport=sse`
 
 ## Implementation Details
 

--- a/pkg/mcp/builder_test.go
+++ b/pkg/mcp/builder_test.go
@@ -277,7 +277,19 @@ func TestBuilder_parseServerURL(t *testing.T) {
 			expectedType: "http",
 			validateConfig: func(t *testing.T, config *LazyMCPServerConfig) {
 				assert.Equal(t, "api.example.com", config.Name)
-				assert.Equal(t, "https://api.example.com/mcp?token=secret", config.URL)
+				assert.Equal(t, "https://api.example.com/mcp", config.URL)
+				assert.Equal(t, "secret", config.Token)
+			},
+		},
+		{
+			name:         "https URL with token and transport=streamable",
+			url:          "https://api.example.com/mcp?token=secret&transport=streamable",
+			expectedType: "http",
+			validateConfig: func(t *testing.T, config *LazyMCPServerConfig) {
+				assert.Equal(t, "api.example.com", config.Name)
+				assert.Equal(t, "https://api.example.com/mcp", config.URL)
+				assert.Equal(t, "secret", config.Token)
+				assert.Equal(t, "streamable", config.HttpTransportMode)
 			},
 		},
 		{


### PR DESCRIPTION
This is a clean rebase + fixup of #289 by @ba0f3. All original changes are preserved; the only addition is removing the `godotenv` import from the example (it wasn't in `go.sum` and the example already reads from `os.Getenv` directly).

## Changes
- **Bug fix**: `Token` and `HttpTransportMode` were being silently dropped when `WithMCPURLs`/`WithMCPPresets` converted `mcp.LazyMCPServerConfig` to `agent.LazyMCPConfig`. Fixed by wiring both fields through.
- **Builder improvement**: `parseServerURL` now strips `?token=` and `?transport=` from the URL and stores them in `config.Token` / `config.HttpTransportMode`, keeping the URL clean.
- **Example**: New `examples/mcp/http-test-agent` for manually testing HTTP MCP server connections with token auth.
- **Docs**: Updated `pkg/mcp/README.md` with URL format examples.

## Testing
- `go build ./...` ✅
- `go test ./pkg/mcp/...` ✅

Closes #289