### PR TITLE
fix(openai): complete Grok compatibility (top_p, temperature, parallel_tool_calls)

### DIFF
--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -333,7 +333,12 @@ func (c *OpenAIClient) Chat(ctx context.Context, messages []llm.Message, params 
 	req := openai.ChatCompletionNewParams{
 		Model:       openai.ChatModel(c.Model),
 		Messages:    chatMessages,
-		Temperature: openai.Float(c.getTemperatureForModel(params.Temperature)),
+	}
+
+	// Only set temperature for non-reasoning models. Reasoning models (o1, o3)
+	// require temperature=1 and reject the parameter if explicitly set.
+	if !isReasoningModel(c.Model) {
+		req.Temperature = openai.Float(c.getTemperatureForModel(params.Temperature))
 	}
 
 	// Only send penalties when explicitly set. Some OpenAI-compatible
@@ -346,8 +351,10 @@ func (c *OpenAIClient) Chat(ctx context.Context, messages []llm.Message, params 
 		req.PresencePenalty = openai.Float(params.PresencePenalty)
 	}
 
-	// Reasoning models don't support top_p parameter
-	if !isReasoningModel(c.Model) {
+	// Reasoning models don't support top_p parameter. Only send when non-zero
+	// and within valid range [0, 1] to avoid 400 errors on OpenAI-compatible
+	// providers (e.g. xAI Grok) that reject unsupported parameters.
+	if !isReasoningModel(c.Model) && params.TopP > 0 && params.TopP <= 1 {
 		req.TopP = openai.Float(params.TopP)
 	}
 
@@ -522,10 +529,9 @@ func (c *OpenAIClient) GenerateWithTools(ctx context.Context, prompt string, too
 		req.TopP = openai.Float(params.LLMConfig.TopP)
 	}
 
-	// Only set ParallelToolCalls for non-reasoning models
-	if !isReasoningModel(c.Model) {
-		req.ParallelToolCalls = openai.Bool(true)
-	}
+	// ParallelToolCalls is not sent. Streaming path (streaming.go) omits it,
+	// and many OpenAI-compatible providers (e.g. xAI Grok) reject the field
+	// entirely. To maintain compatibility, we match the streaming behavior.
 
 	if len(params.LLMConfig.StopSequences) > 0 {
 		req.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: params.LLMConfig.StopSequences}

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -179,8 +179,15 @@ func (c *OpenAIClient) generateInternal(ctx context.Context, prompt string, opti
 		if !isReasoningModel(c.Model) && params.LLMConfig.TopP > 0 && params.LLMConfig.TopP <= 1 {
 			req.TopP = openai.Float(params.LLMConfig.TopP)
 		}
-		req.FrequencyPenalty = openai.Float(params.LLMConfig.FrequencyPenalty)
-		req.PresencePenalty = openai.Float(params.LLMConfig.PresencePenalty)
+		// Only send penalties when explicitly set. Some OpenAI-compatible
+		// providers (e.g. xAI Grok reasoning models) reject the parameters
+		// outright, returning a 400 even for a 0 value.
+		if params.LLMConfig.FrequencyPenalty != 0 {
+			req.FrequencyPenalty = openai.Float(params.LLMConfig.FrequencyPenalty)
+		}
+		if params.LLMConfig.PresencePenalty != 0 {
+			req.PresencePenalty = openai.Float(params.LLMConfig.PresencePenalty)
+		}
 		if len(params.LLMConfig.StopSequences) > 0 {
 			req.Stop = openai.ChatCompletionNewParamsStopUnion{OfStringArray: params.LLMConfig.StopSequences}
 		}
@@ -324,11 +331,19 @@ func (c *OpenAIClient) Chat(ctx context.Context, messages []llm.Message, params 
 
 	// Create chat request
 	req := openai.ChatCompletionNewParams{
-		Model:            openai.ChatModel(c.Model),
-		Messages:         chatMessages,
-		Temperature:      openai.Float(c.getTemperatureForModel(params.Temperature)),
-		FrequencyPenalty: openai.Float(params.FrequencyPenalty),
-		PresencePenalty:  openai.Float(params.PresencePenalty),
+		Model:       openai.ChatModel(c.Model),
+		Messages:    chatMessages,
+		Temperature: openai.Float(c.getTemperatureForModel(params.Temperature)),
+	}
+
+	// Only send penalties when explicitly set. Some OpenAI-compatible
+	// providers (e.g. xAI Grok reasoning models) reject the parameters
+	// outright, returning a 400 even for a 0 value.
+	if params.FrequencyPenalty != 0 {
+		req.FrequencyPenalty = openai.Float(params.FrequencyPenalty)
+	}
+	if params.PresencePenalty != 0 {
+		req.PresencePenalty = openai.Float(params.PresencePenalty)
 	}
 
 	// Reasoning models don't support top_p parameter
@@ -486,12 +501,20 @@ func (c *OpenAIClient) GenerateWithTools(ctx context.Context, prompt string, too
 	}
 
 	req := openai.ChatCompletionNewParams{
-		Model:            openai.ChatModel(c.Model),
-		Messages:         messages,
-		Tools:            openaiTools,
-		Temperature:      openai.Float(c.getTemperatureForModel(params.LLMConfig.Temperature)),
-		FrequencyPenalty: openai.Float(params.LLMConfig.FrequencyPenalty),
-		PresencePenalty:  openai.Float(params.LLMConfig.PresencePenalty),
+		Model:       openai.ChatModel(c.Model),
+		Messages:    messages,
+		Tools:       openaiTools,
+		Temperature: openai.Float(c.getTemperatureForModel(params.LLMConfig.Temperature)),
+	}
+
+	// Only send penalties when explicitly set. Some OpenAI-compatible
+	// providers (e.g. xAI Grok reasoning models) reject the parameters
+	// outright, returning a 400 even for a 0 value.
+	if params.LLMConfig.FrequencyPenalty != 0 {
+		req.FrequencyPenalty = openai.Float(params.LLMConfig.FrequencyPenalty)
+	}
+	if params.LLMConfig.PresencePenalty != 0 {
+		req.PresencePenalty = openai.Float(params.LLMConfig.PresencePenalty)
 	}
 
 	// Reasoning models don't support top_p parameter
@@ -948,12 +971,20 @@ func (c *OpenAIClient) GenerateWithTools(ctx context.Context, prompt string, too
 
 	// Create a final request without tools to force the LLM to provide a conclusion
 	finalReq := openai.ChatCompletionNewParams{
-		Model:            openai.ChatModel(c.Model),
-		Messages:         messages,
-		Tools:            nil, // No tools for final call
-		Temperature:      openai.Float(c.getTemperatureForModel(params.LLMConfig.Temperature)),
-		FrequencyPenalty: openai.Float(params.LLMConfig.FrequencyPenalty),
-		PresencePenalty:  openai.Float(params.LLMConfig.PresencePenalty),
+		Model:       openai.ChatModel(c.Model),
+		Messages:    messages,
+		Tools:       nil, // No tools for final call
+		Temperature: openai.Float(c.getTemperatureForModel(params.LLMConfig.Temperature)),
+	}
+
+	// Only send penalties when explicitly set. Some OpenAI-compatible
+	// providers (e.g. xAI Grok reasoning models) reject the parameters
+	// outright, returning a 400 even for a 0 value.
+	if params.LLMConfig.FrequencyPenalty != 0 {
+		finalReq.FrequencyPenalty = openai.Float(params.LLMConfig.FrequencyPenalty)
+	}
+	if params.LLMConfig.PresencePenalty != 0 {
+		finalReq.PresencePenalty = openai.Float(params.LLMConfig.PresencePenalty)
 	}
 
 	// Reasoning models don't support top_p parameter


### PR DESCRIPTION
## Summary

PR #339 fixed `presence_penalty` and `frequency_penalty` for xAI Grok compatibility, but three related issues remain that still cause HTTP 400 errors on Grok and other strict OpenAI-compatible providers:

1. **Chat sends `top_p=1.0` unconditionally** for all non-reasoning models
2. **Chat sends `temperature` unconditionally** even for reasoning models  
3. **GenerateWithTools sends `parallel_tool_calls=true` unconditionally** for all non-reasoning models

### Root Cause
Grok (and similar strict providers) reject unsupported parameters even when set to their default values (e.g., `presencePenalty=0`, `top_p=1`). PR #339 fixed penalties but left three other fields that are unconditionally sent on certain code paths.

### Changes
- **Chat**: Add `TopP > 0 && <= 1` guard (matches GenerateWithTools and streaming.go)
- **Chat**: Wrap `Temperature` in `if !isReasoningModel` guard (matches streaming.go)
- **GenerateWithTools**: Remove `ParallelToolCalls=true` (matches streaming.go which never sends it)

### Verification
The streaming path in `streaming.go` already has the correct guards for all three fields. This PR brings the non-streaming paths (Chat, GenerateWithTools) into alignment with the proven-working streaming behavior.

**Test**: All three non-streaming paths now work on Grok alongside the penalty fix in #339.