### PR TITLE
Suppress Codecov bot comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+comment:
+  layout: ""
+  require_changes: false
+  behavior: once


### PR DESCRIPTION
Codecov coverage tracking is useful, but the bot comments on every PR add noise.

This config keeps coverage uploads and badges while disabling PR comments.

- Codecov will still upload coverage data
- Badge still displays on README
- Bot comments suppressed on PRs