### PR TITLE
fix(gemini): synthesize final answer when tool turn ends with no content

### DIFF
--- a/pkg/llm/gemini/streaming.go
+++ b/pkg/llm/gemini/streaming.go
@@ -369,6 +369,11 @@ func (c *GeminiClient) generateWithToolsAndStream(ctx context.Context, prompt st
 
 	// Track captured content for final iteration replay if filtering is enabled
 	var capturedContentEvents []interfaces.StreamEvent
+	// Track whether any tool was actually executed across iterations. Used to
+	// decide whether an iteration that returns no tool calls and no content
+	// should fall through to the final-synthesis call (forcing the model to
+	// answer from tool results) instead of returning an empty response.
+	var executedAnyTool bool
 	// Build tool map for quick lookup
 	toolMap := make(map[string]interfaces.Tool)
 	for _, tool := range tools {
@@ -466,6 +471,18 @@ func (c *GeminiClient) generateWithToolsAndStream(ctx context.Context, prompt st
 
 		// If no tool calls, we're done with the iteration loop
 		if len(toolCalls) == 0 {
+			// The model produced no content AND no tool call, but tools ran in
+			// an earlier iteration: the model ended the turn without
+			// synthesizing the tool results into an answer (observed with
+			// Gemini on large tool outputs, where it emits a function call and
+			// then an empty candidate). Returning here yields an empty
+			// response even though the conversation holds tool results. Break
+			// instead so the final-call-without-tools below forces a textual
+			// answer. The maxIterations-exhaustion path already relies on that
+			// same synthesis call.
+			if !hasContent && executedAnyTool {
+				break
+			}
 			// No tool calls means we have received the final response content
 			// If content was filtered (captured), we need to replay it now
 			if shouldFilter && len(iterationContentEvents) > 0 {
@@ -479,6 +496,8 @@ func (c *GeminiClient) generateWithToolsAndStream(ctx context.Context, prompt st
 			}
 			return "", nil
 		}
+
+		executedAnyTool = true
 
 		// Execute tools and add results to conversation
 		c.logger.Info(ctx, "Processing tool calls in streaming", map[string]interface{}{
@@ -632,7 +651,7 @@ func (c *GeminiClient) generateWithToolsAndStream(ctx context.Context, prompt st
 		return "", nil
 	}
 
-	c.logger.Info(ctx, "Maximum iterations reached, making final call without tools", map[string]interface{}{
+	c.logger.Info(ctx, "Tool loop ended, making final call without tools to synthesize answer", map[string]interface{}{
 		"maxIterations": maxIterations,
 	})
 

--- a/pkg/llm/gemini/streaming_test.go
+++ b/pkg/llm/gemini/streaming_test.go
@@ -1,0 +1,134 @@
+package gemini
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// collectEvents drains every event from eventCh until it is closed.
+func collectEvents(eventCh <-chan interfaces.StreamEvent) []interfaces.StreamEvent {
+	var events []interfaces.StreamEvent
+	for event := range eventCh {
+		events = append(events, event)
+	}
+	return events
+}
+
+// TestStreamResponse_ChunksAndReassembles verifies that streamResponse emits
+// content-delta events that, when concatenated, reproduce the input exactly
+// regardless of whether the length is a multiple of the chunk size.
+func TestStreamResponse_ChunksAndReassembles(t *testing.T) {
+	client := &GeminiClient{}
+
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "empty", response: ""},
+		{name: "shorter than chunk", response: "hello"},
+		{name: "exactly one chunk", response: strings.Repeat("a", 50)},
+		{name: "spans multiple chunks with remainder", response: strings.Repeat("b", 123)},
+		{name: "multibyte content", response: strings.Repeat("héllo wörld ", 20)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventCh := make(chan interfaces.StreamEvent, 16)
+			go func() {
+				defer close(eventCh)
+				client.streamResponse(context.Background(), tt.response, eventCh)
+			}()
+
+			events := collectEvents(eventCh)
+
+			// Every emitted event must be a content delta, and concatenating
+			// their content must reproduce the input exactly.
+			var b strings.Builder
+			for i, event := range events {
+				if event.Type != interfaces.StreamEventContentDelta {
+					t.Fatalf("event %d: type = %v, want StreamEventContentDelta", i, event.Type)
+				}
+				if event.Content == "" {
+					t.Fatalf("event %d: emitted an empty content delta", i)
+				}
+				if event.Timestamp.IsZero() {
+					t.Fatalf("event %d: missing timestamp", i)
+				}
+				b.WriteString(event.Content)
+			}
+			if got := b.String(); got != tt.response {
+				t.Fatalf("reassembled content = %q, want %q", got, tt.response)
+			}
+
+			// Verify the exact number of chunks: ceil(len/chunkSize).
+			const chunkSize = 50
+			wantChunks := (len(tt.response) + chunkSize - 1) / chunkSize
+			if len(events) != wantChunks {
+				t.Fatalf("chunk count = %d, want %d", len(events), wantChunks)
+			}
+			// No chunk may exceed the chunk size.
+			for i, event := range events {
+				if len(event.Content) > chunkSize {
+					t.Fatalf("event %d: chunk length %d exceeds chunkSize %d", i, len(event.Content), chunkSize)
+				}
+			}
+		})
+	}
+}
+
+// TestStreamResponse_StopsEarlyOnContextCancel verifies that streamResponse
+// stops emitting after the context is cancelled mid-stream, rather than
+// draining every chunk. The response is 200 bytes (4 chunks of 50); we read
+// one chunk, cancel, and assert it does not deliver the remaining chunks.
+func TestStreamResponse_StopsEarlyOnContextCancel(t *testing.T) {
+	client := &GeminiClient{}
+
+	const chunkSize = 50
+	response := strings.Repeat("x", 4*chunkSize) // 4 chunks total
+
+	// Unbuffered channel so each send blocks until we read it, giving us
+	// precise control over when cancellation takes effect.
+	eventCh := make(chan interfaces.StreamEvent)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		client.streamResponse(ctx, response, eventCh)
+	}()
+
+	// Read exactly one chunk, then cancel before reading the next.
+	received := 0
+	first, ok := <-eventCh
+	if !ok {
+		t.Fatal("channel closed before any chunk was sent")
+	}
+	if first.Type != interfaces.StreamEventContentDelta {
+		t.Fatalf("first event type = %v, want StreamEventContentDelta", first.Type)
+	}
+	received++
+	cancel()
+
+	// Drain whatever is left. Because the send is select'd against ctx.Done(),
+	// streamResponse must return without sending all 4 chunks. Note streamResponse
+	// does not close eventCh itself, so we rely on `done` to know it returned.
+	drain := make(chan int, 1)
+	go func() {
+		extra := 0
+		for range eventCh {
+			extra++
+		}
+		drain <- extra
+	}()
+
+	<-done         // streamResponse returned (no deadlock)
+	close(eventCh) // safe: producer has returned, only the drain goroutine reads
+	received += <-drain
+
+	if received >= 4 {
+		t.Fatalf("received %d chunks; expected early stop with fewer than 4", received)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes Gemini streaming returning an **empty response** when a tool-using turn ends with a function call followed by an empty candidate (no final text part).

**Root cause:** in `generateWithToolsAndStream`, an iteration that returned no tool calls and no content exited immediately with `"", nil`. The "final call without tools" synthesis — which forces the model to produce a textual answer from the accumulated tool results — only ran when `maxIterations` was reached. So when the model called a tool and then ended the turn with an empty candidate (no further tool call, no text), synthesis was skipped and the function returned an empty string, even though the conversation already held a valid tool result.

**Fix:** track whether any tool executed (`executedAnyTool`). On an iteration that yields no tool calls and no content after a tool has run, `break` into the existing final-synthesis call instead of returning empty.

## Example

```
tool_use(some_tool) -> tool_result(...) -> content_complete(0) -> message_stop(0)
```

Before: accumulated content is `""` → empty response returned to the caller, despite the tool having returned a result.

After: the empty turn breaks into the final-call-without-tools synthesis ("provide your final response..."), so the model emits content_delta events and returns a non-empty answer derived from the tool result.

## Behavior
- Turns that already produce content are unaffected (existing return path).
- `DisableFinalSummary` is still honored — when set, synthesis is skipped as before.
- The `maxIterations`-exhaustion path is unchanged; this reuses the same synthesis on the early-empty case.

## How we found it
A caller drained the stream into a single text response and parsed that text. Some tool-using requests intermittently produced an empty parse result. Logging each stream event showed the pattern clearly:

A working turn:
```
tool_use -> tool_result -> content_delta -> content_delta -> message_stop
=> accumulated content: non-empty
```

A failing turn (same prompt, same tool):
```
tool_use -> tool_result -> content_complete(0) -> message_stop(0)
=> accumulated content: ""   (empty, no content_delta at all)
```

In the failing case the model emitted a function call and then ended the turn with an empty candidate, so no `content_delta` was ever produced. Because that iteration had no tool calls and no content, the loop returned early and never reached the final-without-tools synthesis — returning an empty string even though the tool result was sitting in the conversation. This change makes that early-empty turn fall through to synthesis so the model produces a final answer.

A related caller-side observation: once synthesis runs against an empty-but-valid tool result, the model may reply with a clarification message (e.g. `{"error": "ambiguous request: ..."}`) rather than returning the empty result as the answer. That is a system-prompt concern for the caller (state that an empty result is a valid final answer), not a defect in this change.

## Test plan
- [ ] Run gemini streaming tests
- [ ] Manual: a tool-using prompt whose model turn ends on a function call with no trailing text now returns a synthesized answer instead of an empty string
