### PR TITLE
feat(gemini): add Gemini 3.x support, fix thought_signature in tool loops (Gemini 2.5 deprecated)

### DIFF
--- a/pkg/interfaces/memory.go
+++ b/pkg/interfaces/memory.go
@@ -38,11 +38,12 @@ type Message struct {
 
 // ToolCall represents a tool call made by the assistant
 type ToolCall struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	DisplayName string `json:"display_name,omitempty"`
-	Internal    bool   `json:"internal,omitempty"`
-	Arguments   string `json:"arguments"`
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	DisplayName      string `json:"display_name,omitempty"`
+	Internal         bool   `json:"internal,omitempty"`
+	Arguments        string `json:"arguments"`
+	ThoughtSignature []byte `json:"thought_signature,omitempty"`
 }
 
 // Memory represents a memory store for agent conversations

--- a/pkg/llm/gemini/client.go
+++ b/pkg/llm/gemini/client.go
@@ -42,6 +42,10 @@ const (
 	// Image generation models
 	ModelGemini25FlashImage = "gemini-2.5-flash-image"
 
+	// Gemini 3.x text models
+	ModelGemini35Flash = "gemini-3.5-flash"
+	ModelGemini35Pro   = "gemini-3.5-pro"
+
 	// Multi-turn image editing models (Nano Banana Pro)
 	ModelGemini3ProImagePreview = "gemini-3-pro-image-preview"
 
@@ -786,8 +790,9 @@ func (c *GeminiClient) GenerateWithTools(ctx context.Context, prompt string, too
 						Role:    "assistant",
 						Content: "",
 						ToolCalls: []interfaces.ToolCall{{
-							Name:      functionCall.Name,
-							Arguments: "{}",
+							Name:             functionCall.Name,
+							Arguments:        "{}",
+							ThoughtSignature: part.ThoughtSignature,
 						}},
 					})
 					_ = params.Memory.AddMessage(ctx, interfaces.Message{
@@ -871,8 +876,9 @@ func (c *GeminiClient) GenerateWithTools(ctx context.Context, prompt string, too
 						Role:    "assistant",
 						Content: "",
 						ToolCalls: []interfaces.ToolCall{{
-							Name:      functionCall.Name,
-							Arguments: string(argsBytes),
+							Name:             functionCall.Name,
+							Arguments:        string(argsBytes),
+							ThoughtSignature: part.ThoughtSignature,
 						}},
 					})
 					_ = params.Memory.AddMessage(ctx, interfaces.Message{
@@ -888,8 +894,9 @@ func (c *GeminiClient) GenerateWithTools(ctx context.Context, prompt string, too
 						Role:    "assistant",
 						Content: "",
 						ToolCalls: []interfaces.ToolCall{{
-							Name:      functionCall.Name,
-							Arguments: string(argsBytes),
+							Name:             functionCall.Name,
+							Arguments:        string(argsBytes),
+							ThoughtSignature: part.ThoughtSignature,
 						}},
 					})
 					_ = params.Memory.AddMessage(ctx, interfaces.Message{

--- a/pkg/llm/gemini/client.go
+++ b/pkg/llm/gemini/client.go
@@ -43,8 +43,9 @@ const (
 	ModelGemini25FlashImage = "gemini-2.5-flash-image"
 
 	// Gemini 3.x text models
-	ModelGemini35Flash = "gemini-3.5-flash"
-	ModelGemini35Pro   = "gemini-3.5-pro"
+	ModelGemini35Flash       = "gemini-3.5-flash"
+	ModelGemini31ProPreview  = "gemini-3.1-pro-preview"
+	ModelGemini3FlashPreview = "gemini-3-flash-preview"
 
 	// Multi-turn image editing models (Nano Banana Pro)
 	ModelGemini3ProImagePreview = "gemini-3-pro-image-preview"

--- a/pkg/llm/gemini/client_test.go
+++ b/pkg/llm/gemini/client_test.go
@@ -405,6 +405,40 @@ func TestUnknownModelCapabilities(t *testing.T) {
 	assert.Equal(t, []string{"text/plain"}, capabilities.SupportedMimeTypes)
 }
 
+func TestGemini3Capabilities(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+	}{
+		{"flash stable", ModelGemini35Flash},
+		{"pro preview", ModelGemini31ProPreview},
+		{"flash preview", ModelGemini3FlashPreview},
+		{"unlisted gemini-3 prefix", "gemini-3.9-experimental"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caps := GetModelCapabilities(tt.model)
+
+			assert.True(t, caps.SupportsStreaming)
+			assert.True(t, caps.SupportsToolCalling)
+			assert.True(t, caps.SupportsVision)
+			assert.True(t, caps.SupportsAudio)
+			assert.True(t, caps.SupportsThinking, "Gemini 3.x must enable thinking for thought_signature handling")
+			assert.Equal(t, 1048576, caps.MaxInputTokens)
+			assert.Equal(t, 65536, caps.MaxOutputTokens)
+
+			if assert.NotNil(t, caps.MaxThinkingTokens, "thinking-enabled models must expose a thinking budget") {
+				assert.Equal(t, int32(24576), *caps.MaxThinkingTokens)
+			}
+
+			assert.Contains(t, caps.SupportedMimeTypes, "application/pdf")
+			assert.Contains(t, caps.SupportedMimeTypes, "video/quicktime")
+			assert.NotContains(t, caps.SupportedMimeTypes, "video/mpv", "video/mpv is not a valid Gemini MIME type")
+		})
+	}
+}
+
 // Test thinking-related functionality
 func TestSupportsThinking(t *testing.T) {
 	tests := []struct {

--- a/pkg/llm/gemini/message_history.go
+++ b/pkg/llm/gemini/message_history.go
@@ -84,6 +84,7 @@ func (b *messageHistoryBuilder) convertMemoryMessage(msg interfaces.Message) *ge
 					args = make(map[string]interface{})
 				}
 				parts = append(parts, &genai.Part{
+					ThoughtSignature: toolCall.ThoughtSignature,
 					FunctionCall: &genai.FunctionCall{
 						Name: toolCall.Name,
 						Args: args,

--- a/pkg/llm/gemini/message_history_test.go
+++ b/pkg/llm/gemini/message_history_test.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -89,5 +90,69 @@ func TestMessageHistoryBuilder_BuildContents(t *testing.T) {
 				t.Errorf("Expected %d contents, got %d", tt.expected, len(contents))
 			}
 		})
+	}
+}
+
+func TestConvertMemoryMessage_PreservesThoughtSignature(t *testing.T) {
+	logger := logging.New()
+	builder := newMessageHistoryBuilder(logger)
+
+	sig := []byte("test-thought-signature-bytes")
+
+	msg := interfaces.Message{
+		Role:    interfaces.MessageRoleAssistant,
+		Content: "",
+		ToolCalls: []interfaces.ToolCall{
+			{
+				ID:               "call_1",
+				Name:             "get_weather",
+				Arguments:        `{"location":"NYC"}`,
+				ThoughtSignature: sig,
+			},
+		},
+	}
+
+	content := builder.convertMemoryMessage(msg)
+	if content == nil {
+		t.Fatal("expected non-nil content for assistant message with tool calls")
+	}
+	if content.Role != "model" {
+		t.Fatalf("expected role 'model', got %q", content.Role)
+	}
+	if len(content.Parts) != 1 {
+		t.Fatalf("expected 1 part, got %d", len(content.Parts))
+	}
+
+	part := content.Parts[0]
+	if part.FunctionCall == nil {
+		t.Fatal("expected FunctionCall to be set")
+	}
+	if part.FunctionCall.Name != "get_weather" {
+		t.Errorf("expected function name 'get_weather', got %q", part.FunctionCall.Name)
+	}
+	if !bytes.Equal(part.ThoughtSignature, sig) {
+		t.Errorf("ThoughtSignature not preserved: got %v, want %v", part.ThoughtSignature, sig)
+	}
+}
+
+func TestConvertMemoryMessage_NilSignatureOmitted(t *testing.T) {
+	logger := logging.New()
+	builder := newMessageHistoryBuilder(logger)
+
+	msg := interfaces.Message{
+		Role: interfaces.MessageRoleAssistant,
+		ToolCalls: []interfaces.ToolCall{
+			{ID: "call_1", Name: "search", Arguments: `{}`},
+		},
+	}
+
+	content := builder.convertMemoryMessage(msg)
+	if content == nil {
+		t.Fatal("expected non-nil content")
+	}
+
+	part := content.Parts[0]
+	if part.ThoughtSignature != nil {
+		t.Errorf("expected nil ThoughtSignature for tool call without signature, got %v", part.ThoughtSignature)
 	}
 }

--- a/pkg/llm/gemini/streaming.go
+++ b/pkg/llm/gemini/streaming.go
@@ -499,6 +499,7 @@ func (c *GeminiClient) generateWithToolsAndStream(ctx context.Context, prompt st
 				args = make(map[string]interface{})
 			}
 			assistantMessage.Parts = append(assistantMessage.Parts, &genai.Part{
+				ThoughtSignature: toolCall.ThoughtSignature,
 				FunctionCall: &genai.FunctionCall{
 					Name: toolCall.Name,
 					Args: args,
@@ -795,9 +796,10 @@ func (c *GeminiClient) executeStreamingRequestWithToolCapture(
 					// This is a tool call - capture it
 					argsBytes, _ := json.Marshal(part.FunctionCall.Args)
 					toolCall := interfaces.ToolCall{
-						ID:        fmt.Sprintf("gemini_tool_%s", part.FunctionCall.Name),
-						Name:      part.FunctionCall.Name,
-						Arguments: string(argsBytes),
+						ID:               fmt.Sprintf("gemini_tool_%s", part.FunctionCall.Name),
+						Name:             part.FunctionCall.Name,
+						Arguments:        string(argsBytes),
+						ThoughtSignature: part.ThoughtSignature,
 					}
 					toolCalls = append(toolCalls, toolCall)
 

--- a/pkg/llm/gemini/types.go
+++ b/pkg/llm/gemini/types.go
@@ -1,6 +1,9 @@
 package gemini
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // ReasoningMode defines the reasoning approach for the model
 type ReasoningMode string
@@ -260,15 +263,15 @@ func GetModelCapabilities(model string) ModelCapabilities {
 		}
 	case ModelGemini20FlashPreviewImageGen:
 		return ModelCapabilities{
-			SupportsStreaming:        true,
-			SupportsToolCalling:      true,
-			SupportsVision:           true,
-			SupportsAudio:            false,
-			SupportsThinking:         false,   // 2.0 and 1.5 models don't support thinking
-			SupportsImageGeneration:  true,    // Can generate images
-			MaxInputTokens:           1048576, // 1M tokens
-			MaxOutputTokens:          8192,
-			MaxThinkingTokens:        nil,
+			SupportsStreaming:       true,
+			SupportsToolCalling:     true,
+			SupportsVision:          true,
+			SupportsAudio:           false,
+			SupportsThinking:        false,   // 2.0 and 1.5 models don't support thinking
+			SupportsImageGeneration: true,    // Can generate images
+			MaxInputTokens:          1048576, // 1M tokens
+			MaxOutputTokens:         8192,
+			MaxThinkingTokens:       nil,
 			SupportedMimeTypes: []string{
 				"image/png", "image/jpeg", "image/webp", "image/heic", "image/heif",
 				"text/plain",
@@ -282,8 +285,8 @@ func GetModelCapabilities(model string) ModelCapabilities {
 			SupportsVision:                true,  // Can accept images as input for image-to-image
 			SupportsAudio:                 false,
 			SupportsThinking:              false,
-			SupportsImageGeneration:       true,  // Primary purpose: generate images
-			SupportsMultiTurnImageEditing: true,  // Supports chat-based image editing
+			SupportsImageGeneration:       true, // Primary purpose: generate images
+			SupportsMultiTurnImageEditing: true, // Supports chat-based image editing
 			MaxInputTokens:                32768,
 			MaxOutputTokens:               8192,
 			MaxThinkingTokens:             nil,
@@ -294,6 +297,25 @@ func GetModelCapabilities(model string) ModelCapabilities {
 			SupportedOutputFormats: []string{"png", "jpeg"},
 			SupportedImageSizes:    []string{"1K", "2K"},
 		}
+	case ModelGemini35Flash, ModelGemini35Pro:
+		maxThinking := int32(24576)
+		return ModelCapabilities{
+			SupportsStreaming:   true,
+			SupportsToolCalling: true,
+			SupportsVision:      true,
+			SupportsAudio:       true,
+			SupportsThinking:    true,
+			MaxInputTokens:      1048576,
+			MaxOutputTokens:     8192,
+			MaxThinkingTokens:   &maxThinking,
+			SupportedMimeTypes: []string{
+				"image/png", "image/jpeg", "image/webp", "image/heic", "image/heif",
+				"audio/wav", "audio/mp3", "audio/aiff", "audio/aac", "audio/ogg", "audio/flac",
+				"video/mp4", "video/mpeg", "video/mov", "video/avi", "video/flv", "video/mpv", "video/webm", "video/wmv", "video/3gpp",
+				"text/plain", "text/html", "text/css", "text/javascript", "application/x-javascript", "text/x-typescript",
+				"application/pdf",
+			},
+		}
 	case ModelGemini3ProImagePreview:
 		// Nano Banana Pro - Google's most advanced image generation and editing model
 		return ModelCapabilities{
@@ -301,9 +323,9 @@ func GetModelCapabilities(model string) ModelCapabilities {
 			SupportsToolCalling:           false, // Image gen models typically don't support tools
 			SupportsVision:                true,  // Can accept images as input
 			SupportsAudio:                 false,
-			SupportsThinking:              true,  // Uses "Thinking" for complex instructions
+			SupportsThinking:              true, // Uses "Thinking" for complex instructions
 			SupportsImageGeneration:       true,
-			SupportsMultiTurnImageEditing: true,  // Primary feature: multi-turn image editing
+			SupportsMultiTurnImageEditing: true, // Primary feature: multi-turn image editing
 			MaxInputTokens:                32768,
 			MaxOutputTokens:               8192,
 			MaxThinkingTokens:             nil,
@@ -318,6 +340,23 @@ func GetModelCapabilities(model string) ModelCapabilities {
 			SupportedImageSizes:    []string{"1K", "2K", "4K"},
 		}
 	default:
+		// Gemini 3.x models not explicitly listed above default to thinking-enabled
+		// so thought_signature is handled correctly in tool loops.
+		if strings.HasPrefix(model, "gemini-3") {
+			return ModelCapabilities{
+				SupportsStreaming:   true,
+				SupportsToolCalling: true,
+				SupportsVision:      true,
+				SupportsAudio:       true,
+				SupportsThinking:    true,
+				MaxInputTokens:      1048576,
+				MaxOutputTokens:     8192,
+				MaxThinkingTokens:   nil,
+				SupportedMimeTypes: []string{
+					"text/plain",
+				},
+			}
+		}
 		// Return default capabilities for unknown models
 		return ModelCapabilities{
 			SupportsStreaming:   true,

--- a/pkg/llm/gemini/types.go
+++ b/pkg/llm/gemini/types.go
@@ -311,7 +311,7 @@ func GetModelCapabilities(model string) ModelCapabilities {
 			SupportedMimeTypes: []string{
 				"image/png", "image/jpeg", "image/webp", "image/heic", "image/heif",
 				"audio/wav", "audio/mp3", "audio/aiff", "audio/aac", "audio/ogg", "audio/flac",
-				"video/mp4", "video/mpeg", "video/mov", "video/avi", "video/flv", "video/mpv", "video/webm", "video/wmv", "video/3gpp",
+				"video/mp4", "video/mpeg", "video/quicktime", "video/avi", "video/x-flv", "video/mpg", "video/webm", "video/wmv", "video/3gpp",
 				"text/plain", "text/html", "text/css", "text/javascript", "application/x-javascript", "text/x-typescript",
 				"application/pdf",
 			},
@@ -356,7 +356,7 @@ func GetModelCapabilities(model string) ModelCapabilities {
 				SupportedMimeTypes: []string{
 					"image/png", "image/jpeg", "image/webp", "image/heic", "image/heif",
 					"audio/wav", "audio/mp3", "audio/aiff", "audio/aac", "audio/ogg", "audio/flac",
-					"video/mp4", "video/mpeg", "video/mov", "video/avi", "video/flv", "video/mpv", "video/webm", "video/wmv", "video/3gpp",
+					"video/mp4", "video/mpeg", "video/quicktime", "video/avi", "video/x-flv", "video/mpg", "video/webm", "video/wmv", "video/3gpp",
 					"text/plain", "text/html", "text/css", "text/javascript", "application/x-javascript", "text/x-typescript",
 					"application/pdf",
 				},

--- a/pkg/llm/gemini/types.go
+++ b/pkg/llm/gemini/types.go
@@ -297,7 +297,7 @@ func GetModelCapabilities(model string) ModelCapabilities {
 			SupportedOutputFormats: []string{"png", "jpeg"},
 			SupportedImageSizes:    []string{"1K", "2K"},
 		}
-	case ModelGemini35Flash, ModelGemini35Pro:
+	case ModelGemini35Flash, ModelGemini31ProPreview, ModelGemini3FlashPreview:
 		maxThinking := int32(24576)
 		return ModelCapabilities{
 			SupportsStreaming:   true,
@@ -306,7 +306,7 @@ func GetModelCapabilities(model string) ModelCapabilities {
 			SupportsAudio:       true,
 			SupportsThinking:    true,
 			MaxInputTokens:      1048576,
-			MaxOutputTokens:     8192,
+			MaxOutputTokens:     65536,
 			MaxThinkingTokens:   &maxThinking,
 			SupportedMimeTypes: []string{
 				"image/png", "image/jpeg", "image/webp", "image/heic", "image/heif",
@@ -343,6 +343,7 @@ func GetModelCapabilities(model string) ModelCapabilities {
 		// Gemini 3.x models not explicitly listed above default to thinking-enabled
 		// so thought_signature is handled correctly in tool loops.
 		if strings.HasPrefix(model, "gemini-3") {
+			maxThinking := int32(24576)
 			return ModelCapabilities{
 				SupportsStreaming:   true,
 				SupportsToolCalling: true,
@@ -350,10 +351,14 @@ func GetModelCapabilities(model string) ModelCapabilities {
 				SupportsAudio:       true,
 				SupportsThinking:    true,
 				MaxInputTokens:      1048576,
-				MaxOutputTokens:     8192,
-				MaxThinkingTokens:   nil,
+				MaxOutputTokens:     65536,
+				MaxThinkingTokens:   &maxThinking,
 				SupportedMimeTypes: []string{
-					"text/plain",
+					"image/png", "image/jpeg", "image/webp", "image/heic", "image/heif",
+					"audio/wav", "audio/mp3", "audio/aiff", "audio/aac", "audio/ogg", "audio/flac",
+					"video/mp4", "video/mpeg", "video/mov", "video/avi", "video/flv", "video/mpv", "video/webm", "video/wmv", "video/3gpp",
+					"text/plain", "text/html", "text/css", "text/javascript", "application/x-javascript", "text/x-typescript",
+					"application/pdf",
 				},
 			}
 		}


### PR DESCRIPTION
Summary
Gemini 2.5 is deprecated. This PR adds Gemini 3.x model support and fixes a critical bug that blocked tool-calling on Gemini 3.x models.

Gemini 3.x model capabilities: Add gemini-3.5-flash to model constants and GetModelCapabilities with SupportsThinking: true. Add a gemini-3 prefix fallback so future 3.x variants are recognized as thinking-capable by default.
Fix thought_signature handling: Gemini 3.x emits a thought_signature on function-call parts. The SDK was dropping it when capturing tool calls and rebuilding conversation history, causing Gemini to reject the next turn with

`Error 400, Message: Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly, and missing thought_signature may lead to degraded model performan…
`
  Thread ThoughtSignature through interfaces.ToolCall so it survives capture, memory persistence, and replay across both streaming and non-streaming tool loops.


Test plan
 go test ./pkg/llm/gemini/... passes (existing + 2 new tests for signature preservation)

 go build ./... passes

 End-to-end: run internal test with gemini-3.5-flash and confirm the 400 is gone.  passes