### PR TITLE
feat(agent): add model usage attribution

### DIFF
--- a/examples/agent-token-usage-simple/main.go
+++ b/examples/agent-token-usage-simple/main.go
@@ -91,6 +91,13 @@ func main() {
 	if len(detailedResponse.ExecutionSummary.UsedSubAgents) > 0 {
 		fmt.Printf("  Sub-Agents Called: %v\n", detailedResponse.ExecutionSummary.UsedSubAgents)
 	}
+	if len(detailedResponse.ExecutionSummary.UsageByModel) > 0 {
+		fmt.Printf("  Usage By Model:\n")
+		for model, usage := range detailedResponse.ExecutionSummary.UsageByModel {
+			fmt.Printf("    %s: %d total tokens (input: %d, output: %d)\n",
+				model, usage.TotalTokens, usage.InputTokens, usage.OutputTokens)
+		}
+	}
 
 	// Display metadata
 	fmt.Printf("\nMetadata:\n")

--- a/pkg/agent/agent_detailed_test.go
+++ b/pkg/agent/agent_detailed_test.go
@@ -41,9 +41,11 @@ func (m *MockLLMForDetailed) GenerateDetailed(ctx context.Context, prompt string
 		Model:      "mock-model",
 		StopReason: "complete",
 		Usage: &interfaces.TokenUsage{
-			InputTokens:  100,
-			OutputTokens: 50,
-			TotalTokens:  150,
+			InputTokens:              100,
+			OutputTokens:             50,
+			TotalTokens:              150,
+			CacheCreationInputTokens: 10,
+			CacheReadInputTokens:     5,
 		},
 		Metadata: map[string]interface{}{
 			"provider": "mock",
@@ -112,10 +114,19 @@ func TestAgentRunDetailed(t *testing.T) {
 	assert.Equal(t, 100, response.Usage.InputTokens)
 	assert.Equal(t, 50, response.Usage.OutputTokens)
 	assert.Equal(t, 150, response.Usage.TotalTokens)
+	assert.Equal(t, 10, response.Usage.CacheCreationInputTokens)
+	assert.Equal(t, 5, response.Usage.CacheReadInputTokens)
 
 	// Verify execution summary
 	assert.Equal(t, 1, response.ExecutionSummary.LLMCalls)
 	assert.True(t, response.ExecutionSummary.ExecutionTimeMs >= 0)
+	assert.Equal(t, interfaces.TokenUsage{
+		InputTokens:              100,
+		OutputTokens:             50,
+		TotalTokens:              150,
+		CacheCreationInputTokens: 10,
+		CacheReadInputTokens:     5,
+	}, response.ExecutionSummary.UsageByModel["mock-model"])
 
 	// Verify metadata
 	assert.NotNil(t, response.Metadata)
@@ -224,18 +235,28 @@ func TestUsageTrackerAggregation(t *testing.T) {
 
 	// Add multiple LLM usages
 	usage1 := &interfaces.TokenUsage{
-		InputTokens:  100,
-		OutputTokens: 50,
-		TotalTokens:  150,
+		InputTokens:              100,
+		OutputTokens:             50,
+		TotalTokens:              150,
+		CacheCreationInputTokens: 8,
 	}
 	tracker.addLLMUsage(usage1, "model1")
 
 	usage2 := &interfaces.TokenUsage{
-		InputTokens:  200,
-		OutputTokens: 75,
-		TotalTokens:  275,
+		InputTokens:          200,
+		OutputTokens:         75,
+		TotalTokens:          275,
+		ReasoningTokens:      12,
+		CacheReadInputTokens: 6,
 	}
 	tracker.addLLMUsage(usage2, "model2")
+
+	usage3 := &interfaces.TokenUsage{
+		InputTokens:  20,
+		OutputTokens: 10,
+		TotalTokens:  30,
+	}
+	tracker.addLLMUsage(usage3, "model1")
 
 	// Add tool calls
 	tracker.addToolCall("tool1")
@@ -249,12 +270,29 @@ func TestUsageTrackerAggregation(t *testing.T) {
 	totalUsage, execSummary, primaryModel := tracker.getResults()
 
 	// Verify aggregated usage
-	assert.Equal(t, 300, totalUsage.InputTokens)  // 100 + 200
-	assert.Equal(t, 125, totalUsage.OutputTokens) // 50 + 75
-	assert.Equal(t, 425, totalUsage.TotalTokens)  // 150 + 275
+	assert.Equal(t, 320, totalUsage.InputTokens)  // 100 + 200 + 20
+	assert.Equal(t, 135, totalUsage.OutputTokens) // 50 + 75 + 10
+	assert.Equal(t, 455, totalUsage.TotalTokens)  // 150 + 275 + 30
+	assert.Equal(t, 12, totalUsage.ReasoningTokens)
+	assert.Equal(t, 8, totalUsage.CacheCreationInputTokens)
+	assert.Equal(t, 6, totalUsage.CacheReadInputTokens)
+
+	assert.Equal(t, interfaces.TokenUsage{
+		InputTokens:              120,
+		OutputTokens:             60,
+		TotalTokens:              180,
+		CacheCreationInputTokens: 8,
+	}, execSummary.UsageByModel["model1"])
+	assert.Equal(t, interfaces.TokenUsage{
+		InputTokens:          200,
+		OutputTokens:         75,
+		TotalTokens:          275,
+		ReasoningTokens:      12,
+		CacheReadInputTokens: 6,
+	}, execSummary.UsageByModel["model2"])
 
 	// Verify execution summary
-	assert.Equal(t, 2, execSummary.LLMCalls)
+	assert.Equal(t, 3, execSummary.LLMCalls)
 	assert.Equal(t, 2, execSummary.ToolCalls)
 	assert.Equal(t, int64(1500), execSummary.ExecutionTimeMs)
 	assert.Len(t, execSummary.UsedTools, 2)

--- a/pkg/agent/usage_tracker.go
+++ b/pkg/agent/usage_tracker.go
@@ -16,6 +16,7 @@ type usageTracker struct {
 	execSummary  *interfaces.ExecutionSummary
 	detailed     bool
 	primaryModel string
+	usageByModel map[string]*interfaces.TokenUsage
 	mu           sync.Mutex
 }
 
@@ -25,8 +26,10 @@ func newUsageTracker(detailed bool) *usageTracker {
 		execSummary: &interfaces.ExecutionSummary{
 			UsedTools:     []string{},
 			UsedSubAgents: []string{},
+			UsageByModel:  map[string]interfaces.TokenUsage{},
 		},
-		detailed: detailed,
+		detailed:     detailed,
+		usageByModel: map[string]*interfaces.TokenUsage{},
 	}
 }
 
@@ -42,11 +45,29 @@ func (ut *usageTracker) addLLMUsage(usage *interfaces.TokenUsage, model string) 
 	ut.totalUsage.OutputTokens += usage.OutputTokens
 	ut.totalUsage.TotalTokens += usage.TotalTokens
 	ut.totalUsage.ReasoningTokens += usage.ReasoningTokens
+	ut.totalUsage.CacheCreationInputTokens += usage.CacheCreationInputTokens
+	ut.totalUsage.CacheReadInputTokens += usage.CacheReadInputTokens
 	ut.execSummary.LLMCalls++
 
 	if ut.primaryModel == "" && model != "" {
 		ut.primaryModel = model
 	}
+
+	if model == "" {
+		model = "unknown"
+	}
+
+	modelUsage := ut.usageByModel[model]
+	if modelUsage == nil {
+		modelUsage = &interfaces.TokenUsage{}
+		ut.usageByModel[model] = modelUsage
+	}
+	modelUsage.InputTokens += usage.InputTokens
+	modelUsage.OutputTokens += usage.OutputTokens
+	modelUsage.TotalTokens += usage.TotalTokens
+	modelUsage.ReasoningTokens += usage.ReasoningTokens
+	modelUsage.CacheCreationInputTokens += usage.CacheCreationInputTokens
+	modelUsage.CacheReadInputTokens += usage.CacheReadInputTokens
 }
 
 func (ut *usageTracker) addToolCall(toolName string) {
@@ -85,6 +106,11 @@ func (ut *usageTracker) getResults() (*interfaces.TokenUsage, *interfaces.Execut
 
 	ut.mu.Lock()
 	defer ut.mu.Unlock()
+
+	ut.execSummary.UsageByModel = make(map[string]interfaces.TokenUsage, len(ut.usageByModel))
+	for model, usage := range ut.usageByModel {
+		ut.execSummary.UsageByModel[model] = *usage
+	}
 
 	return ut.totalUsage, ut.execSummary, ut.primaryModel
 }

--- a/pkg/interfaces/agent.go
+++ b/pkg/interfaces/agent.go
@@ -16,4 +16,5 @@ type ExecutionSummary struct {
 	ExecutionTimeMs int64
 	UsedTools       []string
 	UsedSubAgents   []string
+	UsageByModel    map[string]TokenUsage
 }


### PR DESCRIPTION
## Description

Adds per-model token usage attribution to detailed agent execution summaries.

`RunDetailed()` already exposes aggregate token usage for an agent run. This change extends `ExecutionSummary` with `UsageByModel`, allowing callers to inspect token usage grouped by the model name reported by each LLM call.

The per-model attribution includes:

- input tokens
- output tokens
- total tokens
- reasoning tokens
- cache creation input tokens
- cache read input tokens

This also fixes a small aggregation gap where cache creation/read token metrics were not included in the total usage tracker aggregation.

Fixes: none

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Tested locally with:

```bash
go test ./pkg/agent ./pkg/interfaces ./pkg/tools
go test ./examples/agent-token-usage-simple
go test ./...
make lint
Updated tests in pkg/agent/agent_detailed_test.go verify:
- aggregate token usage still accumulates across LLM calls
- token usage is grouped by model in ExecutionSummary.UsageByModel
- repeated calls to the same model are accumulated correctly
- reasoning tokens are included in total and per-model usage
- cache creation/read token metrics are included in aggregation
Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules