### PR TITLE
fix(tracing): report streaming errors to generation spans

### DIFF
--- a/pkg/tracing/traced_llm.go
+++ b/pkg/tracing/traced_llm.go
@@ -287,11 +287,19 @@ func (m *TracedLLM) GenerateWithToolsStream(ctx context.Context, prompt string, 
 	// Start a goroutine to proxy events and handle span completion
 	go func() {
 		defer close(wrappedChan)
+
+		var streamErr error
+
 		defer func() {
 			// When streaming is complete, create tool call spans and end main span
 			endTime := time.Now()
 			duration := endTime.Sub(startTime)
 			span.SetAttribute("duration_ms", duration.Milliseconds())
+
+			// Record streaming error on span if one was captured (#328)
+			if streamErr != nil {
+				span.RecordError(streamErr)
+			}
 
 			// Get tool calls from context and create spans using TraceGeneration if any exist
 			toolCalls := GetToolCallsFromContext(ctx)
@@ -306,25 +314,40 @@ func (m *TracedLLM) GenerateWithToolsStream(ctx context.Context, prompt string, 
 					model = streamingLLM.Name()
 				}
 
+				// Build metadata, including error if the stream failed mid-flight (#328)
+				metadata := map[string]any{
+					"streaming": true,
+					"tools":     len(tools),
+				}
+				if streamErr != nil {
+					metadata["error"] = streamErr.Error()
+				}
+
+				responseText := "streaming_response"
+				if streamErr != nil {
+					if m.shouldIncludeContent() {
+						responseText = "<error>"
+					} else {
+						responseText = "<redacted>"
+					}
+				}
+
 				// Create spans using TraceGeneration which handles tool calls correctly
 				if adapter, ok := m.tracer.(*OTELTracerAdapter); ok {
-					_, _ = adapter.otelTracer.TraceGeneration(ctx, model, prompt, "streaming_response", startTime, endTime, map[string]any{ //nolint:gosec
-						"streaming": true,
-						"tools":     len(tools),
-					})
+					_, _ = adapter.otelTracer.TraceGeneration(ctx, model, prompt, responseText, startTime, endTime, metadata) //nolint:gosec
 				} else if tracer, ok := m.tracer.(*OTELLangfuseTracer); ok {
-					_, _ = tracer.TraceGeneration(ctx, model, prompt, "streaming_response", startTime, endTime, map[string]any{ //nolint:gosec
-						"streaming": true,
-						"tools":     len(tools),
-					})
+					_, _ = tracer.TraceGeneration(ctx, model, prompt, responseText, startTime, endTime, metadata) //nolint:gosec
 				}
 			}
 
 			span.End()
 		}()
 
-		// Proxy all events from the original channel
+		// Proxy all events from the original channel, capturing any error event (#328)
 		for event := range originalChan {
+			if event.Type == interfaces.StreamEventError && event.Error != nil {
+				streamErr = event.Error
+			}
 			wrappedChan <- event
 		}
 	}()

--- a/pkg/tracing/traced_llm_error_test.go
+++ b/pkg/tracing/traced_llm_error_test.go
@@ -1,0 +1,142 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+type errorStreamLLM struct {
+	streamErr error
+}
+
+func (*errorStreamLLM) Generate(context.Context, string, ...interfaces.GenerateOption) (string, error) {
+	return "", nil
+}
+
+func (*errorStreamLLM) GenerateWithTools(context.Context, string, []interfaces.Tool, ...interfaces.GenerateOption) (string, error) {
+	return "", nil
+}
+
+func (*errorStreamLLM) GenerateDetailed(context.Context, string, ...interfaces.GenerateOption) (*interfaces.LLMResponse, error) {
+	return &interfaces.LLMResponse{}, nil
+}
+
+func (*errorStreamLLM) GenerateWithToolsDetailed(context.Context, string, []interfaces.Tool, ...interfaces.GenerateOption) (*interfaces.LLMResponse, error) {
+	return &interfaces.LLMResponse{}, nil
+}
+
+func (*errorStreamLLM) GenerateStream(context.Context, string, ...interfaces.GenerateOption) (<-chan interfaces.StreamEvent, error) {
+	return nil, nil
+}
+
+func (m *errorStreamLLM) GenerateWithToolsStream(ctx context.Context, _ string, _ []interfaces.Tool, _ ...interfaces.GenerateOption) (<-chan interfaces.StreamEvent, error) {
+	AddToolCallToContext(ctx, ToolCall{Name: "test_tool", Timestamp: time.Now().Format(time.RFC3339)})
+	ch := make(chan interfaces.StreamEvent, 1)
+	if m.streamErr != nil {
+		ch <- interfaces.StreamEvent{Type: interfaces.StreamEventError, Error: m.streamErr}
+	} else {
+		ch <- interfaces.StreamEvent{Type: interfaces.StreamEventContentComplete, Content: "complete"}
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (*errorStreamLLM) Name() string            { return "test" }
+func (*errorStreamLLM) SupportsStreaming() bool { return true }
+
+func TestGenerateWithToolsStreamGenerationSpan(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		includeContent bool
+		streamErr      error
+		wantError      string
+		wantResponse   string
+	}{
+		{
+			name:           "error with content included",
+			includeContent: true,
+			streamErr:      errors.New("stream interrupted"),
+			wantError:      "stream interrupted",
+			wantResponse:   "<error>",
+		},
+		{
+			name:           "error with content redacted",
+			includeContent: false,
+			streamErr:      errors.New("stream interrupted"),
+			wantError:      "stream interrupted",
+			wantResponse:   "<redacted>",
+		},
+		{
+			name:           "successful stream preserves response placeholder",
+			includeContent: false,
+			wantResponse:   "streaming_response",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exporter := tracetest.NewInMemoryExporter()
+			provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+			otelTracer := &OTELLangfuseTracer{
+				tracerProvider: provider,
+				tracer:         provider.Tracer("test"),
+				enabled:        true,
+				IncludeContent: tc.includeContent,
+			}
+			traced := NewTracedLLM(&errorStreamLLM{streamErr: tc.streamErr}, NewOTELTracerAdapter(otelTracer)).(*TracedLLM)
+
+			stream, err := traced.GenerateWithToolsStream(context.Background(), "secret prompt", nil)
+			if err != nil {
+				t.Fatalf("GenerateWithToolsStream() error = %v", err)
+			}
+			for range stream {
+			}
+
+			var generation sdktrace.ReadOnlySpan
+			for _, span := range exporter.GetSpans() {
+				for _, attr := range span.Attributes {
+					if string(attr.Key) == "langfuse.observation.type" && attr.Value.AsString() == "generation" {
+						generation = span.Snapshot()
+					}
+				}
+			}
+			if generation == nil {
+				t.Fatal("generation span was not exported")
+			}
+
+			attributes := make(map[string]string)
+			for _, attr := range generation.Attributes() {
+				attributes[string(attr.Key)] = attr.Value.AsString()
+			}
+			if got := attributes["langfuse.observation.metadata.error"]; got != tc.wantError {
+				t.Errorf("error metadata = %q, want %q", got, tc.wantError)
+			}
+			if got := attributes["gen_ai.completion.0.content"]; got != tc.wantResponse {
+				t.Errorf("generation response = %q, want %q", got, tc.wantResponse)
+			}
+
+			if tc.streamErr != nil {
+				var foundErrorEvent bool
+				for _, span := range exporter.GetSpans() {
+					if span.Name != "llm.generate_with_tools_stream" {
+						continue
+					}
+					for _, event := range span.Events {
+						if event.Name == "exception" {
+							foundErrorEvent = true
+						}
+					}
+				}
+				if !foundErrorEvent {
+					t.Error("main streaming span did not record the stream error")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

When a streaming LLM request fails, the Langfuse `TraceGeneration` span was still emitted with the successful-looking `streaming_response` value and without error metadata. This made failed generations appear successful.

This change captures `interfaces.StreamEventError`, records the error on the main streaming span, and adds `metadata["error"]` to the generation span. Failed streams now use explicit `<error>` or `<redacted>` response placeholders, while successful streams preserve the existing `streaming_response` behavior.

Fixes #328

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

The following tests and checks passed locally:

- `go test -count=1 ./pkg/tracing`
- `go test -race -count=1 ./pkg/tracing`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./pkg/tracing`
- `golangci-lint run ./...`
- `gosec ./...`
- `gofmt` and `git diff --check`

The regression tests cover both content policies, successful-stream compatibility, error metadata, and exception events on the main streaming span.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules