### PR TITLE
feat: sessions, hooks/plugins, skills, consolidation, runs, caching and LLM transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1205,6 +1205,7 @@ For more detailed information, you can also refer to the following documents:
 - [Configuration Merge](docs/config-merge.md)
 - [Sub-Agents](docs/subagents.md)
 - [Multi-Agent Patterns](docs/multi-agent.md) - sequential, parallel, loop, graph
+- [Agent Capabilities](docs/capabilities.md) - sessions, runs, hooks, skills, consolidation
 - [Token Usage Tracking](docs/token-usage-tracking.md)
 - [Development](docs/development.md)
 - [Upgrading](docs/upgrading.md) - breaking changes and migration paths

--- a/README.md
+++ b/README.md
@@ -23,156 +23,35 @@ Join our Discord server to collaborate, share what you're building, and get comm
 ### Core Capabilities
 - 🧠 **Multi-Model Intelligence**: Seamless integration with OpenAI, Anthropic, and Google Vertex AI (Gemini models).
 - 🔧 **Modular Tool Ecosystem**: Expand agent capabilities with plug-and-play tools for web search, data retrieval, and custom operations
-- 📝 **Advanced Memory Management**: Persistent conversation tracking with buffer and vector-based retrieval options
-- 🔌 **MCP Integration**: Support for Model Context Protocol (MCP) servers via HTTP and stdio transports
+- 📝 **Advanced Memory Management**: Persistent conversation tracking with buffer, vector-based retrieval and summarization
+- 🔌 **MCP Integration**: Model Context Protocol servers over streamable HTTP, SSE and stdio
 - 📊 **Token Usage Tracking**: Built-in token counting for cost monitoring, usage analytics, and optimization
+- 💬 **Session Persistence** *(NEW)*: Durable conversations with scoped state, listing and resume — in-memory, Postgres or SQLite. [Docs](docs/capabilities.md#sessions)
+- 📚 **Agent Skills** *(NEW)*: `SKILL.md` capability bundles loaded from disk, with progressive disclosure so a large library stays cheap. [Docs](docs/capabilities.md#skills)
+- 🌙 **Memory Consolidation** *(NEW)*: Distil an idle conversation into durable facts — merges, corrections and generalizations — proposed for review rather than silently written. [Docs](docs/capabilities.md#memory-consolidation)
+- ⚡ **Prompt Caching** *(NEW)*: Capability-aware caching that tells you which providers honor it, instead of silently doing nothing. [Docs](docs/capabilities.md#prompt-caching)
 
 ### Enterprise-Ready
 - 🚦 **Built-in Guardrails**: Comprehensive safety mechanisms for responsible AI deployment
 - 📈 **Complete Observability**: Integrated tracing and logging for monitoring and debugging
 - 🏢 **Enterprise Multi-tenancy**: Securely support multiple organizations with isolated resources
+- 🪝 **Hooks & Plugins** *(NEW)*: Intercept every tool call to audit, deny, rewrite or redact — bundled as named plugins, reaching all LLM providers. [Docs](docs/capabilities.md#hooks-and-plugins)
+- ⏱️ **Background Runs** *(NEW)*: Run identity, a live registry and cancel-by-ID, so work in flight can be observed and stopped. [Docs](docs/capabilities.md#background-runs)
 
 ### Development Experience
 - 🛠️ **Structured Task Framework**: Plan, approve, and execute complex multi-step operations
 - 📄 **Declarative Configuration**: Define sophisticated agents and tasks using intuitive YAML definitions
 - 🧙 **Zero-Effort Bootstrapping**: Auto-generate complete agent configurations from simple system prompts
+- 🕸️ **Multi-Agent Patterns** *(NEW)*: Sequential, parallel, loop and graph composition over a registry of agents. [Docs](docs/multi-agent.md)
+- 🔀 **Agent Transfer** *(NEW)*: Let the model hand a conversation to a better-suited agent through a constrained tool call. [Docs](docs/capabilities.md#llm-driven-transfer)
+- 🧩 **Tool Pipeline** *(NEW)*: One ordered decorator chain around every tool call, reaching all providers without touching any. [Docs](docs/tool-pipeline.md)
 
-## New
-
-Highlights from the current development line. Full details, including every
-breaking change and its migration path, are in **[docs/upgrading.md](docs/upgrading.md)**.
-
-Most of this line is corrective — several features were not doing what they
-claimed. That is reflected below: the removals and fixes are listed because they
-change behaviour you may be relying on, not because they are achievements.
-
-### New API at a glance
-
-| API | What it gives you |
-| --- | --- |
-| `agent.WithToolDecorator(d)` | Interpose on every tool call — audit, deny, rewrite, time |
-| `agent.ToolDecorator` | The decorator signature: `func([]interfaces.Tool) []interfaces.Tool` |
-| `agent.UnwrapTool(t)` | Recover the concrete tool underneath a decorator chain |
-| `agent.ForwardOptionalToolInterfaces(t)` | Forward `DisplayName`/`Internal` when writing a decorator |
-| `interfaces.AsConversationMemory(m)` | Ask for conversation ops, seeing through decorators |
-| `interfaces.AsAdminConversationMemory(m)` | Same, for cross-org operations |
-| `interfaces.UnwrapMemory(m)` | The innermost `Memory` in a decorator chain |
-| `interfaces.MemoryUnwrapper` | Implement on your own `Memory` decorators |
-| `tools.WithSubAgentContext(ctx, parent, sub)` | Record a sub-agent invocation and its depth |
-| `tools.GetRecursionDepth(ctx)` | Current sub-agent recursion depth |
-| `tools.IsSubAgentCall(ctx)` | Whether this run is nested inside another agent |
-| `tools.ValidateRecursionDepth(ctx)` | Error once `tools.MaxRecursionDepth` is exceeded |
-| `agentconfig.WithLocalPath(path)` | Load config from a specific file |
-
-The `pkg/tools` sub-agent helpers already existed unexported; they are now public
-and are the counter the recursion guard actually enforces. The identically-named
-functions in `pkg/agent` delegate to them.
-
-### 🔐 Remote configuration loading removed
-
-`pkg/agentconfig` used to fetch agent YAML over HTTP and unmarshal it straight
-into a config whose `mcp:` section names a **local executable to run**. A
-compromised configuration service therefore had arbitrary command execution
-inside the agent process, with every API key in the environment inherited by the
-child. The transport is gone; configuration loads from local files only. Local
-YAML, including `mcp:`, is unchanged.
-
-→ [Migration path](docs/upgrading.md#security-fix-remote-configuration-loading-removed)
-
-### 🚦 Input guardrails now actually apply
-
-Guardrails ran *after* the user message was written to memory, and the providers
-build their request from memory. With memory configured — the normal case —
-**the model was shown the unguarded input and `ProcessInput` had no effect**.
-Guardrails now run first, and the guarded text is what is persisted and sent.
-
-If you rely on guardrails to strip secrets or block injection, they were not
-doing so. You may see rejections fire for the first time after upgrading.
-
-**Output guardrails now run too.** `ProcessOutput` previously had one call site,
-reached by one of five terminal paths — not including the default one. Every
-complete-response path is now guarded, and guarded text is what gets persisted.
-Streamed deltas remain an exception; see
-[guardrails.md](docs/guardrails.md#output-guardrails).
-
-→ [Details](docs/upgrading.md#input-guardrails-now-actually-apply) ·
-[Guardrails](docs/guardrails.md)
-
-### 🧩 Tool decorator pipeline
-
-Interpose on every tool call — audit, deny, rewrite arguments, bound output —
-without touching any LLM provider:
-
-```go
-agent, err := agent.NewAgent(
-    agent.WithLLM(llm),
-    agent.WithTools(searchTool, deployTool),
-    agent.WithToolDecorator(auditing),
-)
-```
-
-Applied at all three composition sites, including the execution-plan path that
-is the SDK's default. Ordering is fixed so a denied call is never recorded as
-executed.
-
-→ [Tool pipeline](docs/tool-pipeline.md)
-
-### 🧠 Memory fixes
-
-- **Summaries no longer destroy history.** Each new summary replaced the
-  previous one while the raw messages had already been cleared, so every
-  summarization after the first discarded all earlier history. The prior summary
-  is now folded in.
-- **Summarization works above a threshold of 100.** The internal buffer was
-  hardcoded to 100 messages, silently disabling the feature for any larger
-  `WithMaxBufferSize`.
-- **Redis summarization thresholds were transposed** — `max_summaries` and
-  `summary_after_messages` now mean what they say.
-- **Decorators no longer hide capabilities.** Wrapping a `RedisMemory` in
-  tracing made `GetAllConversations` and its siblings silently return empty. Use
-  `interfaces.AsConversationMemory`; give your own decorators an `Unwrap`.
-
-→ [Memory](docs/memory.md) · [Details](docs/upgrading.md#behaviour-changes)
-
-### ⚡ Concurrency and cancellation
-
-- **`Agent` is safe for concurrent `Run`.** It mutated a shared field from the
-  run path on its default configuration, so a parent fanning out to two
-  sub-agents raced without the caller writing concurrent code.
-- **Cancelling a run stops its sub-agents.** They were detached from the parent
-  context and could keep running for up to 30 minutes, still writing to shared
-  memory.
-- **One recursion counter.** Two independent counters existed with identical key
-  strings but different key types; only one guarded anything.
-
-→ [Sub-agents](docs/subagents.md)
-
-### 📊 `ExecutionSummary.ToolCalls` counts calls
-
-It previously incremented only the first time a tool was seen, so it always
-equalled `len(UsedTools)` — forty calls to one tool reported `1`. Dashboards
-will show higher, correct numbers.
-
-→ [Token usage tracking](docs/token-usage-tracking.md)
-
-### 🗑️ Removals and deprecations
-
-| Item | Status | Why |
-| --- | --- | --- |
-| Remote config loading | **Removed** | Arbitrary command execution |
-| `pkg/workflow` | **Removed** | No execution logic, no importers, corrupted its own state |
-| Anthropic 1h `CacheTTL` | **Removed** | Sent without its beta header, so never honored — callers were billed at the 5-minute rate |
-| `interfaces.TaskExecutor` | **Deprecated** | No type in the module satisfies it |
-
-→ [Full list](docs/upgrading.md#removals)
-
-### 🧪 Shared test doubles
-
-`internal/testutil` provides concurrency-safe `FakeLLM`, `FakeTool`,
-`FakeMemory`, `FakeTracer` and friends, replacing a dozen hand-rolled mocks
-none of which were safe under `-race`.
-
-→ [Development](docs/development.md#test-doubles)
+> **Upgrading an existing deployment?** This line removes remote configuration
+> loading (it allowed the config service to execute local binaries) and fixes
+> several features that were silently not working — most importantly **input
+> guardrails, which had no effect whenever memory was configured**. See
+> [docs/upgrading.md](docs/upgrading.md) for every behaviour change, removal and
+> migration path.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ A powerful Go framework for building production-ready AI agents that seamlessly 
 
 📖 **[docs.goagents.dev](https://docs.goagents.dev/)** — Full documentation, guides, and reference.
 
-## Community
-
-[![Discord](https://img.shields.io/badge/Discord-Join%20Our%20Community-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.com/invite/MjJbDG2nQZ)
-
-Join our Discord server to collaborate, share what you're building, and get community support for agent-sdk-go!
-
 ## Features
 
 ### Core Capabilities
@@ -1189,5 +1183,4 @@ Contributions welcome via GitHub issues and pull requests.
 | Resource | Link |
 |----------|------|
 | Documentation | [docs.goagents.dev](https://docs.goagents.dev/) |
-| Discord | [Join Community](https://discord.com/invite/MjJbDG2nQZ) |
 | GitHub | [Ingenimax/agent-sdk-go](https://github.com/Ingenimax/agent-sdk-go) |

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,0 +1,305 @@
+# Agent Capabilities
+
+Seven subsystems, each usable on its own. They compose, but nothing here
+requires adopting the rest.
+
+| Package | What it gives you |
+| --- | --- |
+| [`pkg/session`](#sessions) | Conversation identity, scoped state, persistence |
+| [`pkg/run`](#background-runs) | Run IDs, a registry, cancel-by-ID |
+| [`pkg/hooks`](#hooks-and-plugins) | Lifecycle callbacks, bundled as plugins |
+| [`pkg/skill`](#skills) | SKILL.md bundles with progressive disclosure |
+| [`pkg/consolidation`](#memory-consolidation) | Idle distillation of memory into facts |
+| [`pkg/llm/cachepolicy`](#prompt-caching) | Honest per-provider caching capability |
+| [`pkg/orchestration`](#llm-driven-transfer) | Model-chosen handoff between agents |
+
+---
+
+## Sessions
+
+```go
+store := session.NewInMemoryStore()
+mgr := session.NewManager(store, session.WithAppName("support"))
+
+s, err := mgr.Create(ctx, "org1", "user42")
+
+// Bind before handing the context to an agent.
+ctx = mgr.Bind(ctx, s)
+answer, err := myAgent.Run(ctx, "how do I rotate a key?")
+```
+
+`Bind` is the important call. Memory derives its scope from an org ID and a
+conversation ID and **fails if either is missing**, which is why a background or
+scheduled run — with no inbound request to inherit from — could not write to
+memory at all. `Bind` supplies both.
+
+`Session.ID` *is* the conversation ID. There is no second ID space and no
+mapping table, so a session and its transcript cannot drift apart. A session
+does not own the transcript; `pkg/memory` already stores it under the same key.
+
+### Scoped state
+
+| Prefix | Scope |
+| --- | --- |
+| *(none)* | This session only |
+| `user:` | Every session belonging to that user |
+| `app:` | Every session in the application |
+| `temp:` | Never persisted — dropped on save |
+
+```go
+s.Set("draft", "in progress")              // private
+s.Set(session.UserPrefix+"tz", "Europe/Oslo") // follows the user
+s.Set(session.TempPrefix+"scratch", "...")    // never stored
+mgr.Save(ctx, s)
+```
+
+Prefixes resolve at the storage layer into separate rows, so shared values are
+genuinely shared rather than copied — and deleting one session does not take its
+user's state with it.
+
+### Persistence
+
+```go
+store, err := session.NewSQLStore(db, session.Postgres) // or session.SQLite
+err = store.Migrate(ctx)
+```
+
+`NewSQLStore` takes a live `*sql.DB` rather than a DSN, so a service that
+already has a pool does not open a second one.
+
+### Fork
+
+```go
+branch, err := mgr.Fork(ctx, "org1", s.ID)
+```
+
+Carries state, not the transcript, and records the parent under `forked_from`.
+
+---
+
+## Background runs
+
+```go
+mgr := run.NewManager()
+
+h := mgr.Start(ctx, myAgent, "long job",
+    run.WithDetached(),
+    run.WithTimeout(10*time.Minute),
+)
+
+fmt.Println(h.ID())
+answer, err := h.Wait(ctx)
+```
+
+`WithDetached` is opt-in. Without it, a run started inside an HTTP handler dies
+when the client disconnects — rarely what "background" is meant to mean. With
+it, only `Cancel` or a timeout stops the run, so pair it with a timeout.
+
+```go
+for _, info := range mgr.Active() {
+    log.Printf("%s running %s for %s", info.ID, info.AgentName, info.Duration())
+}
+err := mgr.Cancel(runID)
+```
+
+`run.FromContext` returns the run **ID**, not the handle. A handle is mutable
+and would be reachable from arbitrary tool code — including MCP tools backed by
+remote processes — which could then mark a run succeeded or forge its result.
+
+`pkg/task` is a different concern: task lifecycle with human approval, not a
+single invocation in flight.
+
+---
+
+## Hooks and plugins
+
+A hook intervenes at one point; a plugin is a named bundle of hooks. They attach
+to the tool set rather than to any provider's loop, so they reach every provider.
+
+```go
+reg := hooks.NewRegistry(
+    hooks.Logging(log.Printf),
+    hooks.AllowList("search", "read_file"),
+    hooks.Redact("[REDACTED]", hooks.CommonSecretPatterns()...),
+    hooks.TruncateResults(8000),
+)
+
+agent, err := agent.NewAgent(
+    agent.WithLLM(llm),
+    agent.WithTools(myTools...),
+    agent.WithToolDecorator(reg.Decorate("my-agent")),
+)
+```
+
+### Writing one
+
+```go
+reg.Register(hooks.Plugin{
+    Name: "business-hours",
+    BeforeTool: func(ctx context.Context, call hooks.ToolCall) (hooks.Outcome, error) {
+        if call.Tool == "send_email" && isOutOfHours() {
+            return hooks.Outcome{
+                Decision: hooks.Deny,
+                Message:  "Email is disabled outside business hours. Summarise instead.",
+            }, nil
+        }
+        return hooks.Outcome{}, nil // the zero value allows
+    },
+})
+```
+
+Four behaviours worth knowing:
+
+- **The zero `Outcome` allows.** A hook that returns early must not block every
+  tool call.
+- **A denial is a result, not an error.** Providers turn a tool error into a
+  tool-result message and continue, so an error would just look like a broken
+  tool. A readable denial lets the model adapt.
+- **A panic in `BeforeTool` fails the call; in `AfterTool` it does not.** A
+  pre-hook gates execution; a post-hook is observational, and a crash in metrics
+  must not discard a result already produced.
+- **The first denial short-circuits.** Later hooks do not run against a call
+  that will not happen.
+
+---
+
+## Skills
+
+```
+skills/
+  incident-triage/
+    SKILL.md
+    runbook.md
+```
+
+```markdown
+---
+name: incident-triage
+description: Triage a production incident and identify the failing component
+---
+
+1. Check the error rate dashboard.
+2. Correlate with recent deploys.
+```
+
+```go
+lib, err := skill.LoadDir("./skills")
+agent, err := agent.NewAgent(
+    agent.WithLLM(llm),
+    agent.WithTools(skill.Tools(lib)...),
+)
+```
+
+Only names and descriptions sit in context; instructions load when the model
+calls `load_skill`. Twenty skills cost twenty one-line descriptions rather than
+twenty documents, which is what makes a large library affordable.
+
+**Skills are never executed.** Bundled files are read, not run. A format that
+silently executes code from a cloned folder is a supply-chain problem. Resource
+reads are confined to the skill's directory; traversal and symlink escape are
+both refused.
+
+---
+
+## Memory consolidation
+
+```go
+store := consolidation.NewInMemoryStore()
+tracker := consolidation.NewActivityTracker(memory.NewConversationBuffer())
+c := consolidation.New(llm, store)
+
+agent, err := agent.NewAgent(agent.WithLLM(llm), agent.WithMemory(tracker))
+
+sched := consolidation.NewScheduler(tracker, c,
+    consolidation.WithIdleFor(15*time.Minute),
+    consolidation.WithPlanCallback(func(scope consolidation.IdleScope, p consolidation.Plan) {
+        log.Print(p.Diff())
+    }),
+)
+sched.Start(ctx)
+defer sched.Stop()
+```
+
+It **proposes**; it does not rewrite. `Plan` produces a reviewable set of facts
+and writes nothing. Apply happens only via `Apply` or `WithAutoApply`, which is
+off by default — a model rewriting memory with no diff and no undo should be a
+deliberate choice. Facts go to a separate store; the transcript is never touched.
+
+Consolidation triggers on **both** quiet time and accumulated writes. Idle time
+alone would consolidate a conversation that barely started; write count alone
+would consolidate one mid-exchange.
+
+### Multi-replica
+
+An in-process ticker fires once per replica. Drive it externally instead:
+
+```go
+sched := consolidation.NewScheduler(tracker, c, consolidation.WithIdleFor(0))
+sched.RunOnce(ctx) // from a CronJob
+```
+
+---
+
+## Prompt caching
+
+Providers differ, and pretending otherwise costs money silently.
+
+```go
+cap := cachepolicy.For("openai")
+fmt.Println(cap.Control)       // automatic
+fmt.Println(cap.Honors())      // false -- CacheConfig has no effect
+fmt.Println(cap.ReportsUsage)  // true  -- cache reads are reported
+
+if err := cachepolicy.CheckConfig("gemini", true); err != nil {
+    log.Warn(err) // caching was configured but will do nothing
+}
+```
+
+| Provider | Control | Reports usage |
+| --- | --- | --- |
+| anthropic | explicit | yes |
+| openai, azureopenai | automatic | yes |
+| gemini | none | no |
+| bedrock, deepseek, ollama, vllm, vertex | none | no |
+
+Control and reporting are tracked separately because OpenAI has no control
+surface yet reports cache reads — a single "supports caching" boolean would
+misrepresent it. OpenAI and Azure now populate
+`TokenUsage.CacheReadInputTokens`, which is the only evidence a caller has that
+caching happened.
+
+---
+
+## LLM-driven transfer
+
+```go
+reg := orchestration.NewAgentRegistry()
+reg.Register("triage", triageAgent)
+reg.Register("billing", billingAgent)
+
+tool := orchestration.NewTransferTool(reg, map[string]string{
+    "triage":  "Route a request to the right specialist",
+    "billing": "Answer invoicing and payment questions",
+})
+
+answer, chain, err := orchestration.RunWithTransfers(
+    ctx, reg, tool, "triage", "why was I charged twice?", 3)
+// chain: [triage billing]
+```
+
+The target is constrained to an enum of registered agents, so a hallucinated
+name is unrepresentable rather than a wasted turn. This replaces parsing
+`[HANDOFF:agent:reason]` out of the model's prose, which required teaching a
+bespoke syntax and broke whenever the model paraphrased it.
+
+Transfer chains are bounded twice — by `maxTransfers` and by a repeat-visit
+counter — because two agents can otherwise bounce a request between them, each
+pass costing a request.
+
+---
+
+## See also
+
+- [Multi-agent patterns](multi-agent.md) — sequential, parallel, loop, graph
+- [Tool pipeline](tool-pipeline.md) — the seam hooks attach to
+- [Memory](memory.md) · [Sub-agents](subagents.md) · [Upgrading](upgrading.md)

--- a/pkg/consolidation/consolidation.go
+++ b/pkg/consolidation/consolidation.go
@@ -1,0 +1,192 @@
+// Package consolidation reviews an agent's accumulated memory when it is idle
+// and distils it into durable facts.
+//
+// The shape of the problem: a long conversation accumulates the same fact
+// stated several ways, facts that later turn out to be wrong, and episodic
+// detail ("I asked X at 14:02") whose value is the general statement inside it.
+// Re-reading all of that on every turn is expensive and gets worse over time.
+//
+// Consolidation runs off the critical path, reads a transcript, and proposes a
+// set of durable facts: merges of duplicates, corrections where a later
+// statement contradicts an earlier one, and generalisations of episodic detail.
+//
+// # It proposes; it does not silently rewrite
+//
+// A Plan is produced first and applied only when asked. Memory is the record of
+// what was said, and a model quietly rewriting it -- with no diff, no
+// provenance and no undo -- is not a trade worth making by default. Apply
+// writes facts to a separate Store; the transcript is never mutated.
+package consolidation
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// FactKind classifies what a consolidation step does.
+type FactKind string
+
+const (
+	// KindNew is a fact not previously recorded.
+	KindNew FactKind = "new"
+	// KindMerged combines duplicates into one statement.
+	KindMerged FactKind = "merged"
+	// KindCorrected supersedes an earlier fact contradicted by a later one.
+	KindCorrected FactKind = "corrected"
+	// KindGeneralized promotes episodic detail into a durable statement.
+	KindGeneralized FactKind = "generalized"
+)
+
+// Fact is one durable statement distilled from a conversation.
+type Fact struct {
+	// ID is stable for a given Subject+Statement, so re-running consolidation
+	// updates a fact rather than duplicating it.
+	ID string `json:"id"`
+
+	// Subject is what the fact is about, used for grouping and lookup.
+	Subject string `json:"subject"`
+
+	// Statement is the fact itself, in plain language.
+	Statement string `json:"statement"`
+
+	// Kind records how the fact was arrived at.
+	Kind FactKind `json:"kind"`
+
+	// Confidence is the model's stated confidence, 0..1.
+	Confidence float64 `json:"confidence"`
+
+	// Supersedes lists fact IDs this one replaces.
+	Supersedes []string `json:"supersedes,omitempty"`
+
+	// Evidence quotes the source text, so a human reviewing a plan can check
+	// the fact against what was actually said rather than trusting it.
+	Evidence string `json:"evidence,omitempty"`
+
+	// ConversationID is where the fact came from.
+	ConversationID string `json:"conversation_id,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Plan is a proposed set of changes, before anything is written.
+type Plan struct {
+	// Facts are the proposed durable statements.
+	Facts []Fact
+
+	// Skipped records what the model declined to consolidate and why, so an
+	// empty plan can be distinguished from a failed one.
+	Skipped []string
+
+	// MessagesRead is how many messages the plan was derived from.
+	MessagesRead int
+}
+
+// Empty reports whether the plan would change nothing.
+func (p Plan) Empty() bool { return len(p.Facts) == 0 }
+
+// Diff renders the plan for review.
+func (p Plan) Diff() string {
+	if p.Empty() {
+		return fmt.Sprintf("No facts proposed from %d messages.", p.MessagesRead)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d fact(s) proposed from %d messages:\n\n", len(p.Facts), p.MessagesRead)
+
+	for _, f := range p.Facts {
+		fmt.Fprintf(&b, "  [%s] %s\n      %s (confidence %.2f)\n",
+			f.Kind, f.Subject, f.Statement, f.Confidence)
+		if len(f.Supersedes) > 0 {
+			fmt.Fprintf(&b, "      supersedes: %s\n", strings.Join(f.Supersedes, ", "))
+		}
+	}
+
+	if len(p.Skipped) > 0 {
+		fmt.Fprintf(&b, "\nSkipped:\n")
+		for _, s := range p.Skipped {
+			fmt.Fprintf(&b, "  - %s\n", s)
+		}
+	}
+	return b.String()
+}
+
+// Store holds consolidated facts. It is deliberately separate from the
+// transcript: consolidation adds a derived layer rather than editing the record
+// of what was said.
+type Store interface {
+	// Put writes or replaces facts.
+	Put(ctx context.Context, orgID string, facts []Fact) error
+
+	// List returns facts for an org, optionally filtered by subject.
+	List(ctx context.Context, orgID, subject string) ([]Fact, error)
+
+	// Delete removes facts by ID.
+	Delete(ctx context.Context, orgID string, ids []string) error
+}
+
+// InMemoryStore keeps facts in process.
+type InMemoryStore struct {
+	mu    sync.RWMutex
+	facts map[string]map[string]Fact // orgID -> factID -> Fact
+}
+
+// NewInMemoryStore creates an in-process fact store.
+func NewInMemoryStore() *InMemoryStore {
+	return &InMemoryStore{facts: map[string]map[string]Fact{}}
+}
+
+// Put implements Store.
+func (s *InMemoryStore) Put(_ context.Context, orgID string, facts []Fact) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.facts[orgID] == nil {
+		s.facts[orgID] = map[string]Fact{}
+	}
+	for _, f := range facts {
+		// A superseding fact removes what it replaces, so a corrected statement
+		// does not sit alongside the thing it corrected.
+		for _, supersededID := range f.Supersedes {
+			delete(s.facts[orgID], supersededID)
+		}
+		s.facts[orgID][f.ID] = f
+	}
+	return nil
+}
+
+// List implements Store.
+func (s *InMemoryStore) List(_ context.Context, orgID, subject string) ([]Fact, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var out []Fact
+	for _, f := range s.facts[orgID] {
+		if subject != "" && !strings.EqualFold(f.Subject, subject) {
+			continue
+		}
+		out = append(out, f)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Subject != out[j].Subject {
+			return out[i].Subject < out[j].Subject
+		}
+		return out[i].Statement < out[j].Statement
+	})
+	return out, nil
+}
+
+// Delete implements Store.
+func (s *InMemoryStore) Delete(_ context.Context, orgID string, ids []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, id := range ids {
+		delete(s.facts[orgID], id)
+	}
+	return nil
+}
+
+var _ Store = (*InMemoryStore)(nil)

--- a/pkg/consolidation/consolidation_test.go
+++ b/pkg/consolidation/consolidation_test.go
@@ -1,0 +1,408 @@
+package consolidation
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/internal/testutil"
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/Ingenimax/agent-sdk-go/pkg/memory"
+	"github.com/Ingenimax/agent-sdk-go/pkg/multitenancy"
+)
+
+func scopedCtx() context.Context {
+	ctx := multitenancy.WithOrgID(context.Background(), "org1")
+	return memory.WithConversationID(ctx, "conv1")
+}
+
+func transcript() []interfaces.Message {
+	return []interfaces.Message{
+		{Role: interfaces.MessageRoleUser, Content: "I always deploy on Tuesdays"},
+		{Role: interfaces.MessageRoleAssistant, Content: "Noted."},
+		{Role: interfaces.MessageRoleUser, Content: "Actually we moved to Thursdays"},
+	}
+}
+
+const planJSON = `{"facts":[
+  {"subject":"deploy schedule","statement":"Deploys happen on Thursdays","kind":"corrected",
+   "confidence":0.9,"evidence":"Actually we moved to Thursdays"}
+],"skipped":["small talk"]}`
+
+func TestPlanProposesWithoutWriting(t *testing.T) {
+	store := NewInMemoryStore()
+	llm := &testutil.FakeLLM{DefaultResponse: planJSON}
+	c := New(llm, store)
+
+	plan, err := c.Plan(scopedCtx(), "org1", "conv1", transcript())
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(plan.Facts) != 1 {
+		t.Fatalf("plan has %d facts, want 1", len(plan.Facts))
+	}
+	if plan.Facts[0].Kind != KindCorrected {
+		t.Errorf("kind = %q, want %q", plan.Facts[0].Kind, KindCorrected)
+	}
+	if plan.MessagesRead != 3 {
+		t.Errorf("MessagesRead = %d, want 3", plan.MessagesRead)
+	}
+
+	// Nothing may have been written yet.
+	stored, _ := store.List(context.Background(), "org1", "")
+	if len(stored) != 0 {
+		t.Errorf("Plan wrote %d facts; it must propose only -- a model rewriting "+
+			"memory with no diff and no undo is not a safe default", len(stored))
+	}
+}
+
+func TestApplyWritesTheFacts(t *testing.T) {
+	store := NewInMemoryStore()
+	c := New(&testutil.FakeLLM{DefaultResponse: planJSON}, store)
+
+	plan, _ := c.Plan(scopedCtx(), "org1", "conv1", transcript())
+	if err := c.Apply(context.Background(), "org1", plan); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	stored, _ := store.List(context.Background(), "org1", "")
+	if len(stored) != 1 {
+		t.Fatalf("stored %d facts, want 1", len(stored))
+	}
+	if !strings.Contains(stored[0].Statement, "Thursdays") {
+		t.Errorf("stored statement = %q", stored[0].Statement)
+	}
+}
+
+func TestPlanDoesNotTouchTheTranscript(t *testing.T) {
+	store := NewInMemoryStore()
+	c := New(&testutil.FakeLLM{DefaultResponse: planJSON}, store)
+
+	mem := memory.NewConversationBuffer()
+	ctx := scopedCtx()
+	for _, m := range transcript() {
+		if err := mem.AddMessage(ctx, m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	before, _ := mem.GetMessages(ctx)
+	plan, _ := c.Plan(ctx, "org1", "conv1", before)
+	_ = c.Apply(ctx, "org1", plan)
+	after, _ := mem.GetMessages(ctx)
+
+	if len(before) != len(after) {
+		t.Errorf("the transcript changed from %d to %d messages; consolidation adds "+
+			"a derived layer and must never edit the record of what was said",
+			len(before), len(after))
+	}
+}
+
+func TestLowConfidenceFactsAreSkipped(t *testing.T) {
+	store := NewInMemoryStore()
+	llm := &testutil.FakeLLM{DefaultResponse: `{"facts":[
+	  {"subject":"guess","statement":"maybe true","kind":"new","confidence":0.2}
+	]}`}
+	c := New(llm, store, WithMinConfidence(0.6))
+
+	plan, err := c.Plan(scopedCtx(), "org1", "conv1", transcript())
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	if len(plan.Facts) != 0 {
+		t.Errorf("a fact below the confidence threshold was kept: %+v", plan.Facts)
+	}
+	if len(plan.Skipped) == 0 {
+		t.Error("a dropped fact should be recorded in Skipped, so an empty plan can " +
+			"be told apart from a filtered one")
+	}
+}
+
+func TestFactIDIsStableSoReRunsUpdate(t *testing.T) {
+	a := FactID("deploy schedule", "Deploys happen on Thursdays")
+	b := FactID("  Deploy Schedule  ", "deploys happen on thursdays")
+	if a != b {
+		t.Errorf("FactID is not stable across case and whitespace: %q vs %q", a, b)
+	}
+	if FactID("x", "one") == FactID("x", "two") {
+		t.Error("different statements must get different IDs")
+	}
+}
+
+func TestSupersedingRemovesTheOldFact(t *testing.T) {
+	store := NewInMemoryStore()
+	ctx := context.Background()
+
+	oldID := FactID("deploy schedule", "Deploys happen on Tuesdays")
+	if err := store.Put(ctx, "org1", []Fact{{
+		ID: oldID, Subject: "deploy schedule",
+		Statement: "Deploys happen on Tuesdays", Kind: KindNew, Confidence: 0.9,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Put(ctx, "org1", []Fact{{
+		ID:         FactID("deploy schedule", "Deploys happen on Thursdays"),
+		Subject:    "deploy schedule",
+		Statement:  "Deploys happen on Thursdays",
+		Kind:       KindCorrected,
+		Supersedes: []string{oldID},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	facts, _ := store.List(ctx, "org1", "")
+	if len(facts) != 1 {
+		t.Fatalf("store holds %d facts, want 1: a correction must remove what it "+
+			"supersedes, not sit alongside it", len(facts))
+	}
+	if !strings.Contains(facts[0].Statement, "Thursdays") {
+		t.Errorf("surviving fact = %q, want the correction", facts[0].Statement)
+	}
+}
+
+func TestModelCodeFencesAreTolerated(t *testing.T) {
+	store := NewInMemoryStore()
+	llm := &testutil.FakeLLM{DefaultResponse: "```json\n" + planJSON + "\n```"}
+	c := New(llm, store)
+
+	plan, err := c.Plan(scopedCtx(), "org1", "conv1", transcript())
+	if err != nil {
+		t.Fatalf("a fenced JSON reply should be tolerated: %v", err)
+	}
+	if len(plan.Facts) != 1 {
+		t.Errorf("plan has %d facts, want 1", len(plan.Facts))
+	}
+}
+
+func TestEmptyPlanIsNotAnError(t *testing.T) {
+	c := New(&testutil.FakeLLM{DefaultResponse: `{"facts":[]}`}, NewInMemoryStore())
+
+	plan, err := c.Plan(scopedCtx(), "org1", "conv1", transcript())
+	if err != nil {
+		t.Fatalf("an empty plan is a normal outcome: %v", err)
+	}
+	if !plan.Empty() {
+		t.Error("plan should report itself empty")
+	}
+	if !strings.Contains(plan.Diff(), "No facts") {
+		t.Errorf("Diff() = %q, want it to say nothing was proposed", plan.Diff())
+	}
+}
+
+func TestExistingFactsAreShownToTheModel(t *testing.T) {
+	store := NewInMemoryStore()
+	_ = store.Put(context.Background(), "org1", []Fact{{
+		ID: "fact_existing", Subject: "tz", Statement: "User is in Oslo", Kind: KindNew,
+	}})
+
+	llm := &testutil.FakeLLM{DefaultResponse: `{"facts":[]}`}
+	c := New(llm, store)
+
+	if _, err := c.Plan(scopedCtx(), "org1", "conv1", transcript()); err != nil {
+		t.Fatal(err)
+	}
+
+	prompts := llm.Prompts()
+	if len(prompts) == 0 || !strings.Contains(prompts[0], "User is in Oslo") {
+		t.Error("existing facts must be shown to the model, or every run re-proposes " +
+			"the same statements")
+	}
+}
+
+// TestActivityTrackerDoesNotBreakWrites pins the property that makes enabling
+// consolidation safe: the tracker has no LLM, no goroutine and no failure mode
+// of its own.
+func TestActivityTrackerDoesNotBreakWrites(t *testing.T) {
+	inner := memory.NewConversationBuffer()
+	tracker := NewActivityTracker(inner)
+	ctx := scopedCtx()
+
+	for _, m := range transcript() {
+		if err := tracker.AddMessage(ctx, m); err != nil {
+			t.Fatalf("AddMessage() error = %v", err)
+		}
+	}
+
+	msgs, err := tracker.GetMessages(ctx)
+	if err != nil {
+		t.Fatalf("GetMessages() error = %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Errorf("read back %d messages, want 3", len(msgs))
+	}
+}
+
+func TestActivityTrackerPreservesCapabilities(t *testing.T) {
+	tracker := NewActivityTracker(memory.NewConversationBuffer())
+	if interfaces.UnwrapMemory(tracker) == interfaces.Memory(tracker) {
+		t.Error("the tracker must unwrap to the memory it decorates, or it hides " +
+			"that memory's optional capabilities")
+	}
+}
+
+func TestIdleScopesRequireBothQuietAndVolume(t *testing.T) {
+	tracker := NewActivityTracker(memory.NewConversationBuffer())
+	ctx := scopedCtx()
+
+	for i := 0; i < 5; i++ {
+		_ = tracker.AddMessage(ctx, interfaces.Message{
+			Role: interfaces.MessageRoleUser, Content: "hi",
+		})
+	}
+
+	// Not yet idle.
+	if got := tracker.IdleScopes(time.Hour, 1); len(got) != 0 {
+		t.Errorf("a busy conversation was reported idle: %+v", got)
+	}
+
+	// Idle, but below the write threshold.
+	if got := tracker.IdleScopes(0, 100); len(got) != 0 {
+		t.Errorf("a conversation below the write threshold was reported: %+v", got)
+	}
+
+	// Both conditions met.
+	idle := tracker.IdleScopes(0, 1)
+	if len(idle) != 1 {
+		t.Fatalf("IdleScopes returned %d, want 1", len(idle))
+	}
+	if idle[0].OrgID != "org1" || idle[0].ConversationID != "conv1" {
+		t.Errorf("scope = %+v, want org1/conv1", idle[0])
+	}
+	if idle[0].Writes != 5 {
+		t.Errorf("Writes = %d, want 5", idle[0].Writes)
+	}
+}
+
+func TestMarkConsolidatedStopsReprocessing(t *testing.T) {
+	tracker := NewActivityTracker(memory.NewConversationBuffer())
+	ctx := scopedCtx()
+	for i := 0; i < 5; i++ {
+		_ = tracker.AddMessage(ctx, interfaces.Message{Role: interfaces.MessageRoleUser, Content: "hi"})
+	}
+
+	idle := tracker.IdleScopes(0, 1)
+	tracker.MarkConsolidated(idle[0].Key)
+
+	if got := tracker.IdleScopes(0, 1); len(got) != 0 {
+		t.Error("a consolidated scope was reported again with no new messages")
+	}
+}
+
+func TestSchedulerRunOnceConsolidatesIdleConversations(t *testing.T) {
+	store := NewInMemoryStore()
+	tracker := NewActivityTracker(memory.NewConversationBuffer())
+	c := New(&testutil.FakeLLM{DefaultResponse: planJSON}, store)
+
+	ctx := scopedCtx()
+	for _, m := range transcript() {
+		_ = tracker.AddMessage(ctx, m)
+	}
+
+	var seen []Plan
+	var mu sync.Mutex
+	s := NewScheduler(tracker, c,
+		WithIdleFor(0), WithMinWrites(1), WithAutoApply(),
+		WithPlanCallback(func(_ IdleScope, p Plan) {
+			mu.Lock()
+			seen = append(seen, p)
+			mu.Unlock()
+		}),
+	)
+
+	s.RunOnce(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != 1 {
+		t.Fatalf("the plan callback fired %d times, want 1", len(seen))
+	}
+	facts, _ := store.List(context.Background(), "org1", "")
+	if len(facts) != 1 {
+		t.Errorf("stored %d facts, want 1 with auto-apply on", len(facts))
+	}
+}
+
+// TestSchedulerDoesNotApplyWithoutOptIn guards the default. A model rewriting an
+// agent's memory unattended should be a choice, not a consequence of switching
+// consolidation on.
+func TestSchedulerDoesNotApplyWithoutOptIn(t *testing.T) {
+	store := NewInMemoryStore()
+	tracker := NewActivityTracker(memory.NewConversationBuffer())
+	c := New(&testutil.FakeLLM{DefaultResponse: planJSON}, store)
+
+	ctx := scopedCtx()
+	for _, m := range transcript() {
+		_ = tracker.AddMessage(ctx, m)
+	}
+
+	var got Plan
+	var mu sync.Mutex
+	s := NewScheduler(tracker, c, WithIdleFor(0), WithMinWrites(1),
+		WithPlanCallback(func(_ IdleScope, p Plan) {
+			mu.Lock()
+			got = p
+			mu.Unlock()
+		}))
+
+	s.RunOnce(context.Background())
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got.Facts) == 0 {
+		t.Error("a plan should still be produced for review")
+	}
+	facts, _ := store.List(context.Background(), "org1", "")
+	if len(facts) != 0 {
+		t.Errorf("%d facts were written without WithAutoApply", len(facts))
+	}
+}
+
+func TestSchedulerStartStopLeavesNoGoroutine(t *testing.T) {
+	tracker := NewActivityTracker(memory.NewConversationBuffer())
+	c := New(&testutil.FakeLLM{DefaultResponse: `{"facts":[]}`}, NewInMemoryStore())
+
+	s := NewScheduler(tracker, c, WithInterval(10*time.Millisecond), WithIdleFor(0), WithMinWrites(1))
+	s.Start(context.Background())
+	s.Start(context.Background()) // second Start must be a no-op
+	time.Sleep(50 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() { s.Stop(); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop() did not return: the scheduler goroutine outlived it")
+	}
+}
+
+func TestSchedulerStopsWithContext(t *testing.T) {
+	tracker := NewActivityTracker(memory.NewConversationBuffer())
+	c := New(&testutil.FakeLLM{DefaultResponse: `{"facts":[]}`}, NewInMemoryStore())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s := NewScheduler(tracker, c, WithInterval(10*time.Millisecond))
+	s.Start(ctx)
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+	s.Stop() // must not hang
+}
+
+func TestRecallReturnsStoredFacts(t *testing.T) {
+	store := NewInMemoryStore()
+	c := New(&testutil.FakeLLM{DefaultResponse: planJSON}, store)
+
+	plan, _ := c.Plan(scopedCtx(), "org1", "conv1", transcript())
+	_ = c.Apply(context.Background(), "org1", plan)
+
+	facts, err := c.Recall(context.Background(), "org1", "deploy schedule")
+	if err != nil {
+		t.Fatalf("Recall() error = %v", err)
+	}
+	if len(facts) != 1 {
+		t.Errorf("Recall returned %d facts, want 1", len(facts))
+	}
+}

--- a/pkg/consolidation/consolidator.go
+++ b/pkg/consolidation/consolidator.go
@@ -1,0 +1,243 @@
+package consolidation
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// Consolidator turns a transcript into a Plan.
+type Consolidator struct {
+	llm   interfaces.LLM
+	store Store
+
+	maxMessages   int
+	minConfidence float64
+}
+
+// Option configures a Consolidator.
+type Option func(*Consolidator)
+
+// WithMaxMessages bounds how many recent messages are examined. Defaults to 100.
+//
+// A bound matters: consolidation is one LLM call over a whole conversation, and
+// an unbounded one grows without limit in both cost and latency.
+func WithMaxMessages(n int) Option {
+	return func(c *Consolidator) {
+		if n > 0 {
+			c.maxMessages = n
+		}
+	}
+}
+
+// WithMinConfidence discards proposed facts below a confidence threshold.
+// Defaults to 0.6.
+func WithMinConfidence(min float64) Option {
+	return func(c *Consolidator) {
+		if min >= 0 && min <= 1 {
+			c.minConfidence = min
+		}
+	}
+}
+
+// New creates a consolidator.
+func New(llm interfaces.LLM, store Store, options ...Option) *Consolidator {
+	c := &Consolidator{
+		llm:           llm,
+		store:         store,
+		maxMessages:   100,
+		minConfidence: 0.6,
+	}
+	for _, option := range options {
+		option(c)
+	}
+	return c
+}
+
+// Plan reads a conversation and proposes durable facts, writing nothing.
+//
+// Existing facts for the org are supplied to the model so it can merge,
+// supersede, or decline to repeat them -- without that context every run would
+// re-propose the same statements.
+func (c *Consolidator) Plan(ctx context.Context, orgID, conversationID string, messages []interfaces.Message) (Plan, error) {
+	if len(messages) == 0 {
+		return Plan{}, nil
+	}
+
+	if len(messages) > c.maxMessages {
+		messages = messages[len(messages)-c.maxMessages:]
+	}
+
+	existing, err := c.store.List(ctx, orgID, "")
+	if err != nil {
+		return Plan{}, fmt.Errorf("consolidation: reading existing facts: %w", err)
+	}
+
+	prompt := buildPrompt(messages, existing)
+
+	response, err := c.llm.Generate(ctx, prompt)
+	if err != nil {
+		return Plan{}, fmt.Errorf("consolidation: %w", err)
+	}
+
+	plan, err := parsePlan(response)
+	if err != nil {
+		return Plan{}, err
+	}
+
+	plan.MessagesRead = len(messages)
+
+	// Stamp and filter. A fact below the confidence threshold is dropped here
+	// rather than written and second-guessed later.
+	kept := plan.Facts[:0]
+	for _, f := range plan.Facts {
+		if f.Confidence < c.minConfidence {
+			plan.Skipped = append(plan.Skipped,
+				fmt.Sprintf("%s (confidence %.2f below threshold %.2f)", f.Statement, f.Confidence, c.minConfidence))
+			continue
+		}
+		if strings.TrimSpace(f.Statement) == "" {
+			continue
+		}
+		f.ID = FactID(f.Subject, f.Statement)
+		f.ConversationID = conversationID
+		f.CreatedAt = time.Now()
+		if f.Kind == "" {
+			f.Kind = KindNew
+		}
+		kept = append(kept, f)
+	}
+	plan.Facts = kept
+
+	return plan, nil
+}
+
+// Apply writes a plan's facts to the store.
+//
+// Separate from Plan on purpose: a caller reviews a Diff and decides. Memory is
+// the record of what was said, and a model rewriting it with no diff, no
+// provenance and no undo is not a default worth having.
+func (c *Consolidator) Apply(ctx context.Context, orgID string, plan Plan) error {
+	if plan.Empty() {
+		return nil
+	}
+	return c.store.Put(ctx, orgID, plan.Facts)
+}
+
+// Consolidate plans and applies in one step, for callers who have already
+// decided to trust it.
+func (c *Consolidator) Consolidate(ctx context.Context, orgID, conversationID string, messages []interfaces.Message) (Plan, error) {
+	plan, err := c.Plan(ctx, orgID, conversationID, messages)
+	if err != nil {
+		return Plan{}, err
+	}
+	if err := c.Apply(ctx, orgID, plan); err != nil {
+		return plan, err
+	}
+	return plan, nil
+}
+
+// Recall returns consolidated facts, ready to include in a prompt.
+func (c *Consolidator) Recall(ctx context.Context, orgID, subject string) ([]Fact, error) {
+	return c.store.List(ctx, orgID, subject)
+}
+
+// FactID derives a stable ID from a fact's subject and statement, so re-running
+// consolidation over the same conversation updates a fact rather than
+// accumulating near-duplicates of it.
+func FactID(subject, statement string) string {
+	normalized := strings.ToLower(strings.TrimSpace(subject)) + "|" +
+		strings.ToLower(strings.TrimSpace(statement))
+	sum := sha256.Sum256([]byte(normalized))
+	return "fact_" + hex.EncodeToString(sum[:8])
+}
+
+func buildPrompt(messages []interfaces.Message, existing []Fact) string {
+	var b strings.Builder
+
+	b.WriteString(`You are consolidating an assistant's memory of a conversation.
+
+Read the transcript and extract durable facts worth remembering across future
+conversations. A durable fact is a stable preference, decision, constraint or
+piece of context -- not a passing detail of this exchange.
+
+For each fact decide a kind:
+  new          something not already recorded
+  merged       several statements of the same thing, combined
+  corrected    a later statement contradicts an earlier recorded fact
+  generalized  a specific episode whose general form is the useful part
+
+Rules:
+- Do not restate an existing fact unchanged.
+- If a fact contradicts an existing one, use "corrected" and list the superseded
+  fact's id in "supersedes".
+- Quote the source text in "evidence".
+- Give an honest confidence between 0 and 1. Low confidence is fine and useful;
+  inflated confidence is not.
+- If nothing is worth keeping, return an empty facts array. That is a valid and
+  common answer.
+
+Reply with JSON only, in this shape:
+{"facts":[{"subject":"...","statement":"...","kind":"new","confidence":0.9,
+"supersedes":["fact_..."],"evidence":"..."}],"skipped":["..."]}
+`)
+
+	if len(existing) > 0 {
+		b.WriteString("\nAlready recorded facts:\n")
+		for _, f := range existing {
+			fmt.Fprintf(&b, "  %s [%s] %s: %s\n", f.ID, f.Kind, f.Subject, f.Statement)
+		}
+	}
+
+	b.WriteString("\nTranscript:\n")
+	for _, m := range messages {
+		content := m.Content
+		if content == "" && len(m.ToolCalls) > 0 {
+			names := make([]string, 0, len(m.ToolCalls))
+			for _, tc := range m.ToolCalls {
+				names = append(names, tc.Name)
+			}
+			content = "(called tools: " + strings.Join(names, ", ") + ")"
+		}
+		if content == "" {
+			continue
+		}
+		fmt.Fprintf(&b, "%s: %s\n", m.Role, content)
+	}
+
+	return b.String()
+}
+
+// parsePlan reads the model's JSON reply, tolerating the code fences models
+// commonly add despite being asked for raw JSON.
+func parsePlan(response string) (Plan, error) {
+	cleaned := strings.TrimSpace(response)
+	if idx := strings.Index(cleaned, "```"); idx >= 0 {
+		cleaned = cleaned[idx+3:]
+		cleaned = strings.TrimPrefix(cleaned, "json")
+		if end := strings.Index(cleaned, "```"); end >= 0 {
+			cleaned = cleaned[:end]
+		}
+	}
+	cleaned = strings.TrimSpace(cleaned)
+
+	if cleaned == "" {
+		return Plan{}, nil
+	}
+
+	var payload struct {
+		Facts   []Fact   `json:"facts"`
+		Skipped []string `json:"skipped"`
+	}
+	if err := json.Unmarshal([]byte(cleaned), &payload); err != nil {
+		return Plan{}, fmt.Errorf("consolidation: model did not return usable JSON: %w", err)
+	}
+
+	return Plan{Facts: payload.Facts, Skipped: payload.Skipped}, nil
+}

--- a/pkg/consolidation/scheduler.go
+++ b/pkg/consolidation/scheduler.go
@@ -1,0 +1,296 @@
+package consolidation
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// ActivityTracker records when a conversation was last written to, so the
+// scheduler can tell which are idle.
+//
+// It is a Memory decorator with no LLM, no goroutine and no failure mode of its
+// own: it stamps a timestamp and delegates. Keeping it that dumb means enabling
+// consolidation cannot break the write path.
+type ActivityTracker struct {
+	inner interfaces.Memory
+
+	mu       sync.Mutex
+	lastSeen map[string]time.Time
+	dirty    map[string]int
+}
+
+// NewActivityTracker wraps a Memory to record write activity.
+func NewActivityTracker(inner interfaces.Memory) *ActivityTracker {
+	return &ActivityTracker{
+		inner:    inner,
+		lastSeen: map[string]time.Time{},
+		dirty:    map[string]int{},
+	}
+}
+
+// AddMessage implements interfaces.Memory.
+func (t *ActivityTracker) AddMessage(ctx context.Context, message interfaces.Message) error {
+	if err := t.inner.AddMessage(ctx, message); err != nil {
+		return err
+	}
+	if key, ok := scopeKey(ctx); ok {
+		t.mu.Lock()
+		t.lastSeen[key] = time.Now()
+		t.dirty[key]++
+		t.mu.Unlock()
+	}
+	return nil
+}
+
+// GetMessages implements interfaces.Memory.
+func (t *ActivityTracker) GetMessages(ctx context.Context, options ...interfaces.GetMessagesOption) ([]interfaces.Message, error) {
+	return t.inner.GetMessages(ctx, options...)
+}
+
+// Clear implements interfaces.Memory.
+func (t *ActivityTracker) Clear(ctx context.Context) error {
+	if key, ok := scopeKey(ctx); ok {
+		t.mu.Lock()
+		delete(t.lastSeen, key)
+		delete(t.dirty, key)
+		t.mu.Unlock()
+	}
+	return t.inner.Clear(ctx)
+}
+
+// Unwrap returns the wrapped Memory, satisfying interfaces.MemoryUnwrapper so
+// this decorator does not hide the optional capabilities of what it wraps.
+func (t *ActivityTracker) Unwrap() interfaces.Memory { return t.inner }
+
+// IdleScope is a conversation that has gone quiet.
+type IdleScope struct {
+	// Key is the memory scope key, "orgID:conversationID".
+	Key string
+	// OrgID and ConversationID are the key's parts.
+	OrgID          string
+	ConversationID string
+	// Writes is how many messages have arrived since it was last consolidated.
+	Writes int
+	// LastSeen is when the last write happened.
+	LastSeen time.Time
+}
+
+// IdleScopes returns conversations that have been quiet for at least idleFor
+// and have accumulated at least minWrites messages.
+//
+// Both conditions matter. Idle time alone would consolidate a conversation that
+// has barely started; write count alone would consolidate one mid-exchange,
+// competing with the user for the same transcript.
+func (t *ActivityTracker) IdleScopes(idleFor time.Duration, minWrites int) []IdleScope {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	cutoff := time.Now().Add(-idleFor)
+	var idle []IdleScope
+
+	for key, seen := range t.lastSeen {
+		if seen.After(cutoff) {
+			continue
+		}
+		if t.dirty[key] < minWrites {
+			continue
+		}
+		orgID, conversationID := splitScopeKey(key)
+		idle = append(idle, IdleScope{
+			Key:            key,
+			OrgID:          orgID,
+			ConversationID: conversationID,
+			Writes:         t.dirty[key],
+			LastSeen:       seen,
+		})
+	}
+	return idle
+}
+
+// MarkConsolidated resets a scope's write counter, so it is not reconsolidated
+// until there is new material.
+func (t *ActivityTracker) MarkConsolidated(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.dirty[key] = 0
+}
+
+var _ interfaces.Memory = (*ActivityTracker)(nil)
+var _ interfaces.MemoryUnwrapper = (*ActivityTracker)(nil)
+
+// Scheduler consolidates idle conversations on a timer. This is the "auto" in
+// auto-dream.
+type Scheduler struct {
+	tracker      *ActivityTracker
+	consolidator *Consolidator
+
+	interval  time.Duration
+	idleFor   time.Duration
+	minWrites int
+	autoApply bool
+
+	onPlan func(scope IdleScope, plan Plan)
+
+	mu      sync.Mutex
+	running bool
+	stop    chan struct{}
+	done    chan struct{}
+}
+
+// SchedulerOption configures a Scheduler.
+type SchedulerOption func(*Scheduler)
+
+// WithInterval sets how often idle conversations are looked for. Defaults to
+// 5 minutes.
+func WithInterval(d time.Duration) SchedulerOption {
+	return func(s *Scheduler) {
+		if d > 0 {
+			s.interval = d
+		}
+	}
+}
+
+// WithIdleFor sets how quiet a conversation must be. Defaults to 15 minutes.
+//
+// Zero is permitted and means "consolidate whatever is eligible now". That is
+// the right setting when RunOnce is driven by an external scheduler, which has
+// already decided it is time -- an in-process idle threshold would then be
+// second-guessing it.
+func WithIdleFor(d time.Duration) SchedulerOption {
+	return func(s *Scheduler) {
+		if d >= 0 {
+			s.idleFor = d
+		}
+	}
+}
+
+// WithMinWrites sets how many new messages must have accumulated. Defaults to 4.
+func WithMinWrites(n int) SchedulerOption {
+	return func(s *Scheduler) {
+		if n > 0 {
+			s.minWrites = n
+		}
+	}
+}
+
+// WithAutoApply writes consolidated facts without review.
+//
+// Off by default. A model rewriting an agent's memory unattended, with no diff
+// and no undo, should be a choice someone makes rather than something that
+// happens because consolidation was switched on.
+func WithAutoApply() SchedulerOption {
+	return func(s *Scheduler) { s.autoApply = true }
+}
+
+// WithPlanCallback registers a function called with every plan produced,
+// whether or not it is applied. This is the review hook.
+func WithPlanCallback(fn func(scope IdleScope, plan Plan)) SchedulerOption {
+	return func(s *Scheduler) { s.onPlan = fn }
+}
+
+// NewScheduler creates an idle-consolidation scheduler.
+func NewScheduler(tracker *ActivityTracker, consolidator *Consolidator, options ...SchedulerOption) *Scheduler {
+	s := &Scheduler{
+		tracker:      tracker,
+		consolidator: consolidator,
+		interval:     5 * time.Minute,
+		idleFor:      15 * time.Minute,
+		minWrites:    4,
+	}
+	for _, option := range options {
+		option(s)
+	}
+	return s
+}
+
+// Start begins the timer. It returns immediately. Calling Start twice is a
+// no-op.
+func (s *Scheduler) Start(ctx context.Context) {
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = true
+	s.stop = make(chan struct{})
+	s.done = make(chan struct{})
+	stop, done := s.stop, s.done
+	s.mu.Unlock()
+
+	go func() {
+		defer close(done)
+
+		ticker := time.NewTicker(s.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				s.RunOnce(ctx)
+			case <-stop:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// Stop halts the timer and waits for the current pass to finish.
+//
+// It waits rather than returning immediately so a caller shutting down can be
+// sure no consolidation is still writing.
+func (s *Scheduler) Stop() {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = false
+	close(s.stop)
+	done := s.done
+	s.mu.Unlock()
+
+	<-done
+}
+
+// RunOnce performs a single consolidation pass. Exported so consolidation can
+// be driven by an external scheduler -- a cron job, a Kubernetes CronJob -- in
+// a multi-replica deployment where an in-process timer would fire N times.
+func (s *Scheduler) RunOnce(ctx context.Context) {
+	for _, scope := range s.tracker.IdleScopes(s.idleFor, s.minWrites) {
+		s.consolidateScope(ctx, scope)
+	}
+}
+
+func (s *Scheduler) consolidateScope(ctx context.Context, scope IdleScope) {
+	// Consolidation needs the same ambient scoping every memory read does.
+	scopedCtx := withScope(ctx, scope.OrgID, scope.ConversationID)
+
+	messages, err := s.tracker.GetMessages(scopedCtx)
+	if err != nil || len(messages) == 0 {
+		return
+	}
+
+	plan, err := s.consolidator.Plan(scopedCtx, scope.OrgID, scope.ConversationID, messages)
+	if err != nil {
+		// A failed pass must never lose anything: nothing has been written, and
+		// the scope stays dirty so the next pass retries it.
+		return
+	}
+
+	if s.onPlan != nil {
+		s.onPlan(scope, plan)
+	}
+
+	if s.autoApply && !plan.Empty() {
+		if err := s.consolidator.Apply(scopedCtx, scope.OrgID, plan); err != nil {
+			return
+		}
+	}
+
+	s.tracker.MarkConsolidated(scope.Key)
+}

--- a/pkg/consolidation/scope.go
+++ b/pkg/consolidation/scope.go
@@ -1,0 +1,42 @@
+package consolidation
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/memory"
+	"github.com/Ingenimax/agent-sdk-go/pkg/multitenancy"
+)
+
+// scopeKey rebuilds the "orgID:conversationID" key memory scopes by.
+func scopeKey(ctx context.Context) (string, bool) {
+	orgID, err := multitenancy.GetOrgID(ctx)
+	if err != nil || orgID == "" {
+		orgID = "default"
+	}
+	conversationID, ok := memory.GetConversationID(ctx)
+	if !ok || conversationID == "" {
+		return "", false
+	}
+	return orgID + ":" + conversationID, true
+}
+
+func splitScopeKey(key string) (orgID, conversationID string) {
+	parts := strings.SplitN(key, ":", 2)
+	if len(parts) != 2 {
+		return "default", key
+	}
+	return parts[0], parts[1]
+}
+
+// withScope stamps the identity a memory read requires.
+//
+// This is why consolidation could not have been built before sessions: a
+// background pass has no inbound request to inherit org and conversation
+// identity from, and memory hard-fails without both.
+func withScope(ctx context.Context, orgID, conversationID string) context.Context {
+	if orgID != "" {
+		ctx = multitenancy.WithOrgID(ctx, orgID)
+	}
+	return memory.WithConversationID(ctx, conversationID)
+}

--- a/pkg/hooks/builtin.go
+++ b/pkg/hooks/builtin.go
@@ -1,0 +1,201 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Logging returns a plugin that records every tool call and its outcome.
+func Logging(log func(format string, args ...any)) Plugin {
+	if log == nil {
+		log = func(string, ...any) {}
+	}
+	return Plugin{
+		Name: "logging",
+		BeforeTool: func(_ context.Context, call ToolCall) (Outcome, error) {
+			log("tool call: %s args=%s agent=%s", call.Tool, call.Arguments, call.AgentName)
+			return Outcome{}, nil
+		},
+		AfterTool: func(_ context.Context, call ToolCall, result string) (string, error) {
+			log("tool result: %s bytes=%d", call.Tool, len(result))
+			return result, nil
+		},
+		OnToolError: func(_ context.Context, call ToolCall, err error) (string, bool) {
+			log("tool error: %s err=%v", call.Tool, err)
+			return "", false
+		},
+	}
+}
+
+// AllowList returns a plugin that denies any tool not named.
+//
+// This is the smallest useful kill switch: an agent handed a broad tool set can
+// be restricted per deployment without rebuilding the tool set.
+func AllowList(allowed ...string) Plugin {
+	permitted := make(map[string]struct{}, len(allowed))
+	for _, name := range allowed {
+		permitted[name] = struct{}{}
+	}
+
+	return Plugin{
+		Name: "allowlist",
+		BeforeTool: func(_ context.Context, call ToolCall) (Outcome, error) {
+			if _, ok := permitted[call.Tool]; ok {
+				return Outcome{}, nil
+			}
+			return Outcome{
+				Decision: Deny,
+				Message: fmt.Sprintf(
+					"The tool %q is not available in this deployment. Do not try it again; use one of the tools you were given.",
+					call.Tool),
+			}, nil
+		},
+	}
+}
+
+// Redact returns a plugin that masks matches in tool results before the model
+// sees them.
+//
+// Results are where secrets most often leak: a tool reads a config file or a
+// log line and hands it straight to the model, which may then repeat it.
+func Redact(replacement string, patterns ...*regexp.Regexp) Plugin {
+	if replacement == "" {
+		replacement = "[REDACTED]"
+	}
+	return Plugin{
+		Name: "redact",
+		AfterTool: func(_ context.Context, _ ToolCall, result string) (string, error) {
+			for _, pattern := range patterns {
+				if pattern == nil {
+					continue
+				}
+				result = pattern.ReplaceAllString(result, replacement)
+			}
+			return result, nil
+		},
+	}
+}
+
+// TruncateResults returns a plugin that caps how much of a tool result reaches
+// the model.
+//
+// An unbounded tool result is the most common way a context window is blown:
+// one directory listing or query dump can dwarf the conversation.
+func TruncateResults(maxBytes int) Plugin {
+	if maxBytes <= 0 {
+		maxBytes = 8000
+	}
+	return Plugin{
+		Name: "truncate",
+		AfterTool: func(_ context.Context, _ ToolCall, result string) (string, error) {
+			if len(result) <= maxBytes {
+				return result, nil
+			}
+			// Say what was dropped. A silent truncation looks to the model like
+			// the data simply ended, and it will reason on a partial answer
+			// without knowing.
+			return fmt.Sprintf("%s\n\n[truncated: %d of %d bytes shown]",
+				result[:maxBytes], maxBytes, len(result)), nil
+		},
+	}
+}
+
+// RetryOnError returns a plugin that reports a tool failure to the model as a
+// readable result instead of an error, so it can adapt rather than see an
+// opaque failure.
+func RetryOnError() Plugin {
+	return Plugin{
+		Name: "retry-on-error",
+		OnToolError: func(_ context.Context, call ToolCall, err error) (string, bool) {
+			return fmt.Sprintf(
+				"The tool %q failed: %v. Consider a different approach or different arguments.",
+				call.Tool, err), true
+		},
+	}
+}
+
+// Metrics collects per-tool call counts, failures and durations.
+type Metrics struct {
+	mu    sync.Mutex
+	calls map[string]int
+	fails map[string]int
+	total map[string]time.Duration
+}
+
+// NewMetrics creates a metrics collector.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		calls: map[string]int{},
+		fails: map[string]int{},
+		total: map[string]time.Duration{},
+	}
+}
+
+// Plugin returns the plugin that feeds this collector.
+func (m *Metrics) Plugin() Plugin {
+	return Plugin{
+		Name: "metrics",
+		BeforeTool: func(_ context.Context, call ToolCall) (Outcome, error) {
+			m.mu.Lock()
+			m.calls[call.Tool]++
+			m.mu.Unlock()
+			return Outcome{}, nil
+		},
+		OnToolError: func(_ context.Context, call ToolCall, _ error) (string, bool) {
+			m.mu.Lock()
+			m.fails[call.Tool]++
+			m.mu.Unlock()
+			return "", false
+		},
+	}
+}
+
+// Calls returns how many times each tool was invoked.
+func (m *Metrics) Calls() map[string]int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[string]int, len(m.calls))
+	for k, v := range m.calls {
+		out[k] = v
+	}
+	return out
+}
+
+// Failures returns how many times each tool failed.
+func (m *Metrics) Failures() map[string]int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[string]int, len(m.fails))
+	for k, v := range m.fails {
+		out[k] = v
+	}
+	return out
+}
+
+// CommonSecretPatterns returns regexps for values that should not reach a model
+// in a tool result.
+//
+// Deliberately conservative: a pattern that over-matches corrupts legitimate
+// output, which is its own failure.
+func CommonSecretPatterns() []*regexp.Regexp {
+	return []*regexp.Regexp{
+		regexp.MustCompile(`(?i)\b(sk|pk)-[A-Za-z0-9]{20,}\b`),              // API keys
+		regexp.MustCompile(`(?i)\bAKIA[0-9A-Z]{16}\b`),                      // AWS access key ID
+		regexp.MustCompile(`(?i)\bghp_[A-Za-z0-9]{36}\b`),                   // GitHub PAT
+		regexp.MustCompile(`\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b`),                // US SSN
+		regexp.MustCompile(`(?i)\b(?:password|passwd|secret)\s*[=:]\s*\S+`), // key=value secrets
+	}
+}
+
+// Describe renders a registry's plugins for logging or a status endpoint.
+func (r *Registry) Describe() string {
+	names := r.Names()
+	if len(names) == 0 {
+		return "no plugins registered"
+	}
+	return "plugins: " + strings.Join(names, ", ")
+}

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -1,0 +1,339 @@
+// Package hooks runs user-supplied callbacks at points in an agent's lifecycle,
+// and bundles related callbacks into named plugins.
+//
+// A Hook observes or intervenes at one point. A Plugin is a named bundle of
+// hooks shipped together — logging, policy enforcement, metrics, redaction —
+// which is what "packaged cross-cutting behavior" means in practice. ADK draws
+// the same distinction between its per-agent callbacks and its Runner-level
+// plugins.
+//
+// # Where hooks run
+//
+//	BeforeTool   before a tool executes; can rewrite arguments or deny the call
+//	AfterTool    after a tool returns; can rewrite the result
+//	OnToolError  when a tool fails; can substitute a result and suppress the error
+//
+// Tool hooks reach every LLM provider, because they attach to the tool set
+// rather than to any provider's loop. See docs/tool-pipeline.md.
+//
+// # Denial
+//
+// A denied tool call returns a message to the model rather than an error. The
+// providers convert a tool error into a tool-result message and keep going, so
+// returning an error would not stop anything -- it would just look like a tool
+// that failed. A denial the model can read is more useful and more honest.
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// ToolCall describes a tool invocation a hook may inspect or alter.
+type ToolCall struct {
+	// Tool is the name of the tool being called.
+	Tool string
+
+	// Arguments is the raw JSON the model supplied.
+	Arguments string
+
+	// AgentName is the agent making the call, when known.
+	AgentName string
+}
+
+// Decision is what a BeforeTool hook wants to happen.
+type Decision int
+
+const (
+	// Allow lets the call proceed. This is the zero value, so a hook that
+	// returns an empty Outcome allows by default rather than silently denying.
+	Allow Decision = iota
+
+	// Modify proceeds with rewritten arguments.
+	Modify
+
+	// Deny blocks the call and returns Message to the model instead.
+	Deny
+)
+
+// Outcome is a BeforeTool hook's verdict.
+//
+// The zero value allows the call, which is deliberate: a hook that returns
+// early, or one written before a new field existed, must not accidentally block
+// every tool.
+type Outcome struct {
+	Decision Decision
+
+	// Arguments replaces the call's arguments when Decision is Modify.
+	Arguments string
+
+	// Message is returned to the model when Decision is Deny.
+	Message string
+}
+
+// BeforeToolFunc runs before a tool executes.
+type BeforeToolFunc func(ctx context.Context, call ToolCall) (Outcome, error)
+
+// AfterToolFunc runs after a tool returns and may rewrite the result.
+type AfterToolFunc func(ctx context.Context, call ToolCall, result string) (string, error)
+
+// OnToolErrorFunc runs when a tool fails. Returning handled=true substitutes
+// the returned result and suppresses the error.
+type OnToolErrorFunc func(ctx context.Context, call ToolCall, err error) (result string, handled bool)
+
+// Plugin is a named bundle of hooks.
+//
+// Name is required: it appears in panic recovery and error messages, and
+// "which plugin denied this?" is unanswerable without it.
+type Plugin struct {
+	Name        string
+	BeforeTool  BeforeToolFunc
+	AfterTool   AfterToolFunc
+	OnToolError OnToolErrorFunc
+}
+
+// Registry holds the plugins an agent runs.
+type Registry struct {
+	mu      sync.RWMutex
+	plugins []Plugin
+}
+
+// NewRegistry creates an empty registry.
+func NewRegistry(plugins ...Plugin) *Registry {
+	r := &Registry{}
+	for _, p := range plugins {
+		r.Register(p)
+	}
+	return r
+}
+
+// Register adds a plugin. Plugins run in registration order.
+func (r *Registry) Register(p Plugin) {
+	if p.Name == "" {
+		p.Name = "unnamed"
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.plugins = append(r.plugins, p)
+}
+
+// Names returns the registered plugin names, in order.
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.plugins))
+	for _, p := range r.plugins {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+func (r *Registry) snapshot() []Plugin {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return append([]Plugin(nil), r.plugins...)
+}
+
+// beforeTool runs every BeforeTool hook in order.
+//
+// The first plugin to deny wins and the rest are skipped: once a call is
+// blocked, running further hooks against a call that will not happen is at best
+// wasted work and at worst misleading in an audit log. Modifications accumulate,
+// so a later hook sees the arguments an earlier one produced.
+func (r *Registry) beforeTool(ctx context.Context, call ToolCall) (Outcome, error) {
+	current := call
+
+	for _, p := range r.snapshot() {
+		if p.BeforeTool == nil {
+			continue
+		}
+
+		outcome, err := r.runBefore(ctx, p, current)
+		if err != nil {
+			return Outcome{}, fmt.Errorf("plugin %q: %w", p.Name, err)
+		}
+
+		switch outcome.Decision {
+		case Deny:
+			message := outcome.Message
+			if message == "" {
+				message = fmt.Sprintf("This tool call was denied by %q.", p.Name)
+			}
+			return Outcome{Decision: Deny, Message: message}, nil
+		case Modify:
+			current.Arguments = outcome.Arguments
+		}
+	}
+
+	if current.Arguments != call.Arguments {
+		return Outcome{Decision: Modify, Arguments: current.Arguments}, nil
+	}
+	return Outcome{Decision: Allow}, nil
+}
+
+// runBefore isolates one hook so a panic inside it cannot take down the run.
+//
+// A logging plugin that dereferences a nil map should produce a failed tool
+// call, not a dead agent with no explanation.
+func (r *Registry) runBefore(ctx context.Context, p Plugin, call ToolCall) (outcome Outcome, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			outcome = Outcome{}
+			err = fmt.Errorf("panic in BeforeTool: %v", recovered)
+		}
+	}()
+	return p.BeforeTool(ctx, call)
+}
+
+// afterTool runs every AfterTool hook in order, threading the result through.
+func (r *Registry) afterTool(ctx context.Context, call ToolCall, result string) string {
+	current := result
+
+	for _, p := range r.snapshot() {
+		if p.AfterTool == nil {
+			continue
+		}
+		next, err := r.runAfter(ctx, p, call, current)
+		if err != nil {
+			// An AfterTool hook is observational or cosmetic. Failing the tool
+			// call because a metrics hook panicked would be a worse outcome
+			// than carrying on with the unmodified result.
+			continue
+		}
+		current = next
+	}
+
+	return current
+}
+
+func (r *Registry) runAfter(ctx context.Context, p Plugin, call ToolCall, result string) (out string, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			out = result
+			err = fmt.Errorf("panic in AfterTool: %v", recovered)
+		}
+	}()
+	return p.AfterTool(ctx, call, result)
+}
+
+// onToolError offers each plugin the chance to handle a tool failure.
+func (r *Registry) onToolError(ctx context.Context, call ToolCall, toolErr error) (string, bool) {
+	for _, p := range r.snapshot() {
+		if p.OnToolError == nil {
+			continue
+		}
+		result, handled := r.runOnError(ctx, p, call, toolErr)
+		if handled {
+			return result, true
+		}
+	}
+	return "", false
+}
+
+func (r *Registry) runOnError(ctx context.Context, p Plugin, call ToolCall, toolErr error) (result string, handled bool) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result = ""
+			handled = false
+		}
+	}()
+	return p.OnToolError(ctx, call, toolErr)
+}
+
+// Decorate returns a tool decorator that applies this registry's hooks.
+//
+// Pass it to agent.WithToolDecorator. Hooks then reach every provider, because
+// the decorator attaches to the tool set rather than to any provider's loop.
+func (r *Registry) Decorate(agentName string) func([]interfaces.Tool) []interfaces.Tool {
+	return func(toolSet []interfaces.Tool) []interfaces.Tool {
+		if r == nil || len(toolSet) == 0 {
+			return toolSet
+		}
+		out := make([]interfaces.Tool, len(toolSet))
+		for i, tool := range toolSet {
+			out[i] = &hookedTool{inner: tool, registry: r, agentName: agentName}
+		}
+		return out
+	}
+}
+
+// hookedTool applies the registry's hooks around one tool.
+type hookedTool struct {
+	inner     interfaces.Tool
+	registry  *Registry
+	agentName string
+}
+
+func (t *hookedTool) Name() string        { return t.inner.Name() }
+func (t *hookedTool) Description() string { return t.inner.Description() }
+
+func (t *hookedTool) Parameters() map[string]interfaces.ParameterSpec {
+	return t.inner.Parameters()
+}
+
+func (t *hookedTool) Run(ctx context.Context, input string) (string, error) {
+	return t.execute(ctx, input, t.inner.Run)
+}
+
+func (t *hookedTool) Execute(ctx context.Context, args string) (string, error) {
+	return t.execute(ctx, args, t.inner.Execute)
+}
+
+func (t *hookedTool) execute(ctx context.Context, args string, invoke func(context.Context, string) (string, error)) (string, error) {
+	call := ToolCall{Tool: t.inner.Name(), Arguments: args, AgentName: t.agentName}
+
+	outcome, err := t.registry.beforeTool(ctx, call)
+	if err != nil {
+		return "", err
+	}
+
+	switch outcome.Decision {
+	case Deny:
+		// Returned as a result, not an error: the providers turn a tool error
+		// into a tool-result message and continue anyway, so an error would
+		// merely look like a broken tool. A readable denial lets the model
+		// adapt.
+		return outcome.Message, nil
+	case Modify:
+		call.Arguments = outcome.Arguments
+	}
+
+	result, execErr := invoke(ctx, call.Arguments)
+	if execErr != nil {
+		if handled, ok := t.registry.onToolError(ctx, call, execErr); ok {
+			return t.registry.afterTool(ctx, call, handled), nil
+		}
+		return "", execErr
+	}
+
+	return t.registry.afterTool(ctx, call, result), nil
+}
+
+// Unwrap returns the tool underneath, satisfying agent.ToolUnwrapper so
+// wrapping does not permanently erase concrete type identity.
+func (t *hookedTool) Unwrap() interfaces.Tool { return t.inner }
+
+// DisplayName forwards the inner tool's display name.
+func (t *hookedTool) DisplayName() string {
+	if d, ok := t.inner.(interfaces.ToolWithDisplayName); ok {
+		return d.DisplayName()
+	}
+	return t.inner.Name()
+}
+
+// Internal forwards the inner tool's internal flag.
+func (t *hookedTool) Internal() bool {
+	if i, ok := t.inner.(interfaces.InternalTool); ok {
+		return i.Internal()
+	}
+	return false
+}
+
+var (
+	_ interfaces.Tool                = (*hookedTool)(nil)
+	_ interfaces.ToolWithDisplayName = (*hookedTool)(nil)
+	_ interfaces.InternalTool        = (*hookedTool)(nil)
+)

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -1,0 +1,313 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Ingenimax/agent-sdk-go/internal/testutil"
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+func decorate(t *testing.T, r *Registry, tool interfaces.Tool) interfaces.Tool {
+	t.Helper()
+	out := r.Decorate("test-agent")([]interfaces.Tool{tool})
+	if len(out) != 1 {
+		t.Fatalf("Decorate returned %d tools, want 1", len(out))
+	}
+	return out[0]
+}
+
+func TestBeforeToolCanDeny(t *testing.T) {
+	inner := &testutil.FakeTool{ToolName: "deploy", Result: "deployed"}
+	r := NewRegistry(Plugin{
+		Name: "guard",
+		BeforeTool: func(context.Context, ToolCall) (Outcome, error) {
+			return Outcome{Decision: Deny, Message: "not in production"}, nil
+		},
+	})
+
+	out, err := decorate(t, r, inner).Execute(context.Background(), "{}")
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if out != "not in production" {
+		t.Errorf("result = %q, want the denial message", out)
+	}
+	if inner.CallCount() != 0 {
+		t.Error("a denied tool was still executed")
+	}
+}
+
+// TestDenialIsAResultNotAnError pins a deliberate choice. The providers convert
+// a tool error into a tool-result message and continue the loop, so returning an
+// error would not stop anything -- it would just look like a broken tool.
+func TestDenialIsAResultNotAnError(t *testing.T) {
+	r := NewRegistry(Plugin{
+		Name: "guard",
+		BeforeTool: func(context.Context, ToolCall) (Outcome, error) {
+			return Outcome{Decision: Deny}, nil
+		},
+	})
+
+	out, err := decorate(t, r, &testutil.FakeTool{ToolName: "x"}).Execute(context.Background(), "{}")
+	if err != nil {
+		t.Errorf("a denial should not surface as an error: %v", err)
+	}
+	if !strings.Contains(out, "guard") {
+		t.Errorf("default denial message %q should name the plugin that denied", out)
+	}
+}
+
+// TestZeroOutcomeAllows guards the most dangerous default in the package. A hook
+// that returns early, or one written before a field existed, must not block
+// every tool call.
+func TestZeroOutcomeAllows(t *testing.T) {
+	inner := &testutil.FakeTool{ToolName: "x", Result: "ran"}
+	r := NewRegistry(Plugin{
+		Name: "noop",
+		BeforeTool: func(context.Context, ToolCall) (Outcome, error) {
+			return Outcome{}, nil // the zero value
+		},
+	})
+
+	out, err := decorate(t, r, inner).Execute(context.Background(), "{}")
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if out != "ran" {
+		t.Errorf("result = %q, want the tool to have run: the zero Outcome must allow", out)
+	}
+}
+
+func TestBeforeToolCanModifyArguments(t *testing.T) {
+	inner := &testutil.FakeTool{ToolName: "search", Result: "ok"}
+	r := NewRegistry(Plugin{
+		Name: "rewriter",
+		BeforeTool: func(_ context.Context, call ToolCall) (Outcome, error) {
+			return Outcome{Decision: Modify, Arguments: `{"q":"rewritten"}`}, nil
+		},
+	})
+
+	if _, err := decorate(t, r, inner).Execute(context.Background(), `{"q":"original"}`); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	calls := inner.Calls()
+	if len(calls) != 1 || calls[0] != `{"q":"rewritten"}` {
+		t.Errorf("tool received %v, want the rewritten arguments", calls)
+	}
+}
+
+func TestModificationsAccumulateAcrossPlugins(t *testing.T) {
+	inner := &testutil.FakeTool{ToolName: "x", Result: "ok"}
+	r := NewRegistry(
+		Plugin{Name: "first", BeforeTool: func(_ context.Context, c ToolCall) (Outcome, error) {
+			return Outcome{Decision: Modify, Arguments: c.Arguments + "+first"}, nil
+		}},
+		Plugin{Name: "second", BeforeTool: func(_ context.Context, c ToolCall) (Outcome, error) {
+			return Outcome{Decision: Modify, Arguments: c.Arguments + "+second"}, nil
+		}},
+	)
+
+	if _, err := decorate(t, r, inner).Execute(context.Background(), "base"); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := inner.Calls()[0]; got != "base+first+second" {
+		t.Errorf("tool received %q, want each plugin to see the previous one's edit", got)
+	}
+}
+
+func TestFirstDenialShortCircuits(t *testing.T) {
+	var secondRan atomic.Bool
+	inner := &testutil.FakeTool{ToolName: "x"}
+
+	r := NewRegistry(
+		Plugin{Name: "denier", BeforeTool: func(context.Context, ToolCall) (Outcome, error) {
+			return Outcome{Decision: Deny, Message: "no"}, nil
+		}},
+		Plugin{Name: "later", BeforeTool: func(context.Context, ToolCall) (Outcome, error) {
+			secondRan.Store(true)
+			return Outcome{}, nil
+		}},
+	)
+
+	if _, err := decorate(t, r, inner).Execute(context.Background(), "{}"); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if secondRan.Load() {
+		t.Error("a plugin ran after the call was already denied")
+	}
+}
+
+func TestAfterToolCanRewriteResults(t *testing.T) {
+	inner := &testutil.FakeTool{ToolName: "x", Result: "the key is sk-abcdefghijklmnopqrstuvwxyz123"}
+	r := NewRegistry(Redact("[REDACTED]", CommonSecretPatterns()...))
+
+	out, err := decorate(t, r, inner).Execute(context.Background(), "{}")
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if strings.Contains(out, "sk-abcdefghijklmnopqrstuvwxyz123") {
+		t.Errorf("result %q still contains the secret", out)
+	}
+	if !strings.Contains(out, "[REDACTED]") {
+		t.Errorf("result %q should show the redaction", out)
+	}
+}
+
+// TestPanicInAHookDoesNotKillTheRun guards containment. A logging plugin that
+// dereferences a nil map should produce a failed tool call, not a dead agent
+// with no explanation.
+func TestPanicInAHookDoesNotKillTheRun(t *testing.T) {
+	inner := &testutil.FakeTool{ToolName: "x", Result: "ran"}
+	r := NewRegistry(Plugin{
+		Name: "buggy",
+		BeforeTool: func(context.Context, ToolCall) (Outcome, error) {
+			var m map[string]string
+			m["boom"] = "panics" //nolint:staticcheck // deliberate: assignment to a nil map
+			return Outcome{}, nil
+		},
+	})
+
+	_, err := decorate(t, r, inner).Execute(context.Background(), "{}")
+	if err == nil {
+		t.Fatal("a panicking hook should surface as an error, not be swallowed")
+	}
+	if !strings.Contains(err.Error(), "buggy") {
+		t.Errorf("error %v should name the plugin that panicked", err)
+	}
+}
+
+// TestPanicInAfterToolDoesNotFailTheCall asserts the asymmetry is deliberate:
+// an AfterTool hook is observational, so a crash in metrics must not discard a
+// tool result that was produced successfully.
+func TestPanicInAfterToolDoesNotFailTheCall(t *testing.T) {
+	inner := &testutil.FakeTool{ToolName: "x", Result: "real result"}
+	r := NewRegistry(Plugin{
+		Name: "buggy-metrics",
+		AfterTool: func(context.Context, ToolCall, string) (string, error) {
+			var m map[string]string
+			m["boom"] = "panics" //nolint:staticcheck // deliberate
+			return "", nil
+		},
+	})
+
+	out, err := decorate(t, r, inner).Execute(context.Background(), "{}")
+	if err != nil {
+		t.Fatalf("an observational hook must not fail the call: %v", err)
+	}
+	if out != "real result" {
+		t.Errorf("result = %q, want the tool's real result preserved", out)
+	}
+}
+
+func TestOnToolErrorCanSubstituteAResult(t *testing.T) {
+	inner := &testutil.FakeTool{ToolName: "flaky", Err: errors.New("upstream down")}
+	r := NewRegistry(RetryOnError())
+
+	out, err := decorate(t, r, inner).Execute(context.Background(), "{}")
+	if err != nil {
+		t.Fatalf("the error should have been handled: %v", err)
+	}
+	if !strings.Contains(out, "flaky") || !strings.Contains(out, "upstream down") {
+		t.Errorf("substituted result %q should describe the failure to the model", out)
+	}
+}
+
+func TestUnhandledToolErrorPropagates(t *testing.T) {
+	sentinel := errors.New("upstream down")
+	inner := &testutil.FakeTool{ToolName: "flaky", Err: sentinel}
+	r := NewRegistry(Logging(nil)) // observes but does not handle
+
+	if _, err := decorate(t, r, inner).Execute(context.Background(), "{}"); !errors.Is(err, sentinel) {
+		t.Errorf("error = %v, want the original error to propagate when unhandled", err)
+	}
+}
+
+func TestAllowListDeniesUnlistedTools(t *testing.T) {
+	blocked := &testutil.FakeTool{ToolName: "delete_everything", Result: "boom"}
+	r := NewRegistry(AllowList("search", "read"))
+
+	out, err := decorate(t, r, blocked).Execute(context.Background(), "{}")
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if blocked.CallCount() != 0 {
+		t.Error("an unlisted tool was executed")
+	}
+	if !strings.Contains(out, "delete_everything") {
+		t.Errorf("denial %q should name the tool", out)
+	}
+}
+
+func TestTruncateAnnouncesWhatItDropped(t *testing.T) {
+	long := strings.Repeat("x", 500)
+	inner := &testutil.FakeTool{ToolName: "dump", Result: long}
+	r := NewRegistry(TruncateResults(100))
+
+	out, err := decorate(t, r, inner).Execute(context.Background(), "{}")
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(out) >= len(long) {
+		t.Error("the result was not truncated")
+	}
+	if !strings.Contains(out, "truncated") {
+		t.Error("truncation must be announced: a silent cut looks to the model " +
+			"like the data simply ended")
+	}
+}
+
+func TestMetricsCountCallsAndFailures(t *testing.T) {
+	m := NewMetrics()
+	good := &testutil.FakeTool{ToolName: "good", Result: "ok"}
+	bad := &testutil.FakeTool{ToolName: "bad", Err: errors.New("nope")}
+
+	r := NewRegistry(m.Plugin(), RetryOnError())
+
+	_, _ = decorate(t, r, good).Execute(context.Background(), "{}")
+	_, _ = decorate(t, r, good).Execute(context.Background(), "{}")
+	_, _ = decorate(t, r, bad).Execute(context.Background(), "{}")
+
+	if got := m.Calls()["good"]; got != 2 {
+		t.Errorf("good calls = %d, want 2", got)
+	}
+	if got := m.Failures()["bad"]; got != 1 {
+		t.Errorf("bad failures = %d, want 1", got)
+	}
+}
+
+func TestHookedToolForwardsOptionalInterfacesAndUnwraps(t *testing.T) {
+	inner := &testutil.FakeTool{ToolName: "raw", Display: "Pretty", IsInternal: true}
+	wrapped := decorate(t, NewRegistry(Logging(nil)), inner)
+
+	named, ok := wrapped.(interfaces.ToolWithDisplayName)
+	if !ok || named.DisplayName() != "Pretty" {
+		t.Error("DisplayName was lost through the hook decorator")
+	}
+	internal, ok := wrapped.(interfaces.InternalTool)
+	if !ok || !internal.Internal() {
+		t.Error("Internal was lost through the hook decorator")
+	}
+	unwrapper, ok := wrapped.(interface{ Unwrap() interfaces.Tool })
+	if !ok || unwrapper.Unwrap() != interfaces.Tool(inner) {
+		t.Error("the hooked tool does not unwrap to the original")
+	}
+}
+
+func TestRegistryDescribesItsPlugins(t *testing.T) {
+	r := NewRegistry(Logging(nil), AllowList("x"))
+	got := r.Describe()
+	if !strings.Contains(got, "logging") || !strings.Contains(got, "allowlist") {
+		t.Errorf("Describe() = %q, want it to name the registered plugins", got)
+	}
+	if NewRegistry().Describe() == "" {
+		t.Error("Describe() on an empty registry should still say something")
+	}
+}
+
+var _ = regexp.MustCompile

--- a/pkg/llm/azureopenai/client.go
+++ b/pkg/llm/azureopenai/client.go
@@ -380,6 +380,14 @@ func (c *AzureOpenAIClient) generateInternal(ctx context.Context, prompt string,
 			TotalTokens:  int(resp.Usage.TotalTokens),
 		}
 
+		// Report prompt tokens served from cache. This provider caches long
+		// prefixes automatically with no control surface, so the cache read is
+		// the only observable evidence that it happened -- without it a caller
+		// cannot tell a cache hit from a full-price request.
+		if resp.Usage.PromptTokensDetails.CachedTokens > 0 {
+			usage.CacheReadInputTokens = int(resp.Usage.PromptTokensDetails.CachedTokens)
+		}
+
 		// Add reasoning tokens if available (for o1 models)
 		if resp.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
 			usage.ReasoningTokens = int(resp.Usage.CompletionTokensDetails.ReasoningTokens)

--- a/pkg/llm/cachepolicy/cachepolicy.go
+++ b/pkg/llm/cachepolicy/cachepolicy.go
@@ -1,0 +1,168 @@
+// Package cachepolicy describes what prompt caching a provider actually
+// supports, so callers are not misled about whether caching happened.
+//
+// Providers differ fundamentally, and an abstraction that hides that does more
+// harm than good:
+//
+//   - Anthropic caches on explicit cache_control breakpoints the caller places.
+//   - OpenAI and Azure OpenAI cache automatically, with no control surface, but
+//     do report how many prompt tokens were served from cache.
+//   - Gemini has both implicit caching and a separate explicit cached-content
+//     API with its own lifecycle.
+//   - Several providers do nothing at all.
+//
+// A single CacheConfig applied uniformly would therefore be a no-op on most
+// providers while looking configured. This package makes the difference
+// inspectable instead: ask what a provider supports before assuming a setting
+// took effect.
+package cachepolicy
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Support describes how much control a provider offers over caching.
+type Support int
+
+const (
+	// None means the provider does no prompt caching.
+	None Support = iota
+
+	// Automatic means the provider caches on its own. Configuration has no
+	// effect, but usage may still be reported.
+	Automatic
+
+	// Explicit means the caller marks what to cache and the setting is honored.
+	Explicit
+)
+
+func (s Support) String() string {
+	switch s {
+	case Explicit:
+		return "explicit"
+	case Automatic:
+		return "automatic"
+	default:
+		return "none"
+	}
+}
+
+// Capability describes one provider's caching behaviour.
+type Capability struct {
+	// Provider is the provider name, matching interfaces.LLM.Name().
+	Provider string
+
+	// Control is how much say the caller has.
+	Control Support
+
+	// ReportsUsage is whether cache hits appear in TokenUsage.
+	//
+	// This is tracked separately from Control on purpose: OpenAI offers no
+	// control at all yet reports cache reads, which is exactly the combination
+	// a single "supports caching" boolean would misrepresent.
+	ReportsUsage bool
+
+	// Notes explains anything a caller would otherwise get wrong.
+	Notes string
+}
+
+// Honors reports whether an explicit CacheConfig has any effect here.
+func (c Capability) Honors() bool { return c.Control == Explicit }
+
+// capabilities is the provider matrix.
+//
+// Deliberately a table rather than per-provider interface methods: it is small,
+// it changes rarely, and having it in one place makes the differences legible
+// at a glance instead of scattered across eight packages.
+var capabilities = map[string]Capability{
+	"anthropic": {
+		Provider:     "anthropic",
+		Control:      Explicit,
+		ReportsUsage: true,
+		Notes: "Caches at explicit cache_control breakpoints. Extended (1h) TTL is not " +
+			"supported: it needs an anthropic-beta header this client does not send.",
+	},
+	"openai": {
+		Provider:     "openai",
+		Control:      Automatic,
+		ReportsUsage: true,
+		Notes: "Caches long prompt prefixes automatically. CacheConfig has no effect; " +
+			"cache reads are reported as CacheReadInputTokens.",
+	},
+	"azureopenai": {
+		Provider:     "azureopenai",
+		Control:      Automatic,
+		ReportsUsage: true,
+		Notes:        "Same automatic prefix caching as OpenAI. CacheConfig has no effect.",
+	},
+	"gemini": {
+		Provider:     "gemini",
+		Control:      None,
+		ReportsUsage: false,
+		Notes: "Gemini supports implicit caching and an explicit cached-content API, " +
+			"neither of which this client uses yet. CacheConfig has no effect.",
+	},
+	"bedrock":  {Provider: "bedrock", Notes: "No prompt caching in this client."},
+	"deepseek": {Provider: "deepseek", Notes: "No prompt caching in this client."},
+	"ollama":   {Provider: "ollama", Notes: "No prompt caching in this client."},
+	"vllm":     {Provider: "vllm", Notes: "No prompt caching in this client."},
+	"vertex":   {Provider: "vertex", Notes: "No prompt caching in this client."},
+}
+
+// For returns the caching capability of a provider.
+//
+// An unknown provider reports no support, which is the safe answer: assuming a
+// provider caches when it does not leads a caller to expect savings that never
+// arrive.
+func For(provider string) Capability {
+	if c, ok := capabilities[strings.ToLower(strings.TrimSpace(provider))]; ok {
+		return c
+	}
+	return Capability{
+		Provider: provider,
+		Notes:    "Unknown provider; assumed to have no prompt caching.",
+	}
+}
+
+// Providers returns every provider in the matrix, sorted.
+func Providers() []string {
+	out := make([]string, 0, len(capabilities))
+	for name := range capabilities {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Explain renders the matrix, for a status endpoint or a startup log.
+func Explain() string {
+	var b strings.Builder
+	b.WriteString("Prompt caching support by provider:\n")
+	for _, name := range Providers() {
+		c := capabilities[name]
+		fmt.Fprintf(&b, "  %-12s control=%-9s reports_usage=%-5t  %s\n",
+			c.Provider, c.Control, c.ReportsUsage, c.Notes)
+	}
+	return b.String()
+}
+
+// CheckConfig reports whether an explicit caching configuration will do
+// anything on a provider.
+//
+// Call it at startup rather than discovering from a flat bill that a setting
+// was inert. Returns nil when the configuration is honored or when no caching
+// was requested.
+func CheckConfig(provider string, requested bool) error {
+	if !requested {
+		return nil
+	}
+	c := For(provider)
+	if c.Honors() {
+		return nil
+	}
+	return fmt.Errorf(
+		"prompt caching was configured but %s does not honor it (control=%s): %s",
+		c.Provider, c.Control, c.Notes)
+}

--- a/pkg/llm/cachepolicy/cachepolicy_test.go
+++ b/pkg/llm/cachepolicy/cachepolicy_test.go
@@ -1,0 +1,101 @@
+package cachepolicy
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestControlAndReportingAreSeparate is the reason this package exists rather
+// than a "supports caching" boolean.
+//
+// OpenAI offers no control at all yet reports cache reads; Anthropic offers
+// control AND reporting; Gemini does neither in this client. A single boolean
+// would misrepresent at least one of them, and a caller would configure caching
+// that silently does nothing.
+func TestControlAndReportingAreSeparate(t *testing.T) {
+	anthropic := For("anthropic")
+	if anthropic.Control != Explicit {
+		t.Errorf("anthropic control = %v, want Explicit", anthropic.Control)
+	}
+	if !anthropic.Honors() {
+		t.Error("anthropic should honor an explicit CacheConfig")
+	}
+
+	openai := For("openai")
+	if openai.Control != Automatic {
+		t.Errorf("openai control = %v, want Automatic", openai.Control)
+	}
+	if openai.Honors() {
+		t.Error("openai must not claim to honor CacheConfig; it has no control surface")
+	}
+	if !openai.ReportsUsage {
+		t.Error("openai does report cached tokens, and that is the only evidence a " +
+			"caller has that caching happened")
+	}
+}
+
+func TestUnknownProviderAssumesNoCaching(t *testing.T) {
+	c := For("some-new-provider")
+	if c.Control != None {
+		t.Errorf("control = %v, want None for an unknown provider", c.Control)
+	}
+	if c.Honors() {
+		t.Error("an unknown provider must not be assumed to honor caching: expecting " +
+			"savings that never arrive is the worse failure")
+	}
+}
+
+func TestProviderLookupIsCaseAndSpaceInsensitive(t *testing.T) {
+	if !For("  Anthropic  ").Honors() {
+		t.Error("provider lookup should tolerate case and surrounding whitespace")
+	}
+}
+
+// TestCheckConfigWarnsOnInertConfiguration is the practical entry point: catch
+// a setting that does nothing at startup, rather than from a flat bill.
+func TestCheckConfigWarnsOnInertConfiguration(t *testing.T) {
+	if err := CheckConfig("anthropic", true); err != nil {
+		t.Errorf("anthropic honors caching, so no warning is expected: %v", err)
+	}
+
+	err := CheckConfig("gemini", true)
+	if err == nil {
+		t.Fatal("configuring caching on a provider that ignores it should be reported")
+	}
+	if !strings.Contains(err.Error(), "gemini") {
+		t.Errorf("error = %v, want it to name the provider", err)
+	}
+
+	if err := CheckConfig("gemini", false); err != nil {
+		t.Errorf("no caching requested, so no warning is expected: %v", err)
+	}
+}
+
+func TestExplainCoversEveryProvider(t *testing.T) {
+	explanation := Explain()
+	for _, provider := range Providers() {
+		if !strings.Contains(explanation, provider) {
+			t.Errorf("Explain() omits %q", provider)
+		}
+	}
+}
+
+func TestAnthropicNotesTheExtendedTTLLimitation(t *testing.T) {
+	notes := For("anthropic").Notes
+	if !strings.Contains(notes, "1h") {
+		t.Error("the anthropic notes should record that extended TTL is unsupported, " +
+			"since that was a silent billing surprise")
+	}
+}
+
+func TestSupportStringsAreStable(t *testing.T) {
+	for support, want := range map[Support]string{
+		None:      "none",
+		Automatic: "automatic",
+		Explicit:  "explicit",
+	} {
+		if got := support.String(); got != want {
+			t.Errorf("Support(%d).String() = %q, want %q", support, got, want)
+		}
+	}
+}

--- a/pkg/llm/openai/client.go
+++ b/pkg/llm/openai/client.go
@@ -290,6 +290,14 @@ func (c *OpenAIClient) generateInternal(ctx context.Context, prompt string, opti
 			TotalTokens:  int(resp.Usage.TotalTokens),
 		}
 
+		// Report prompt tokens served from cache. This provider caches long
+		// prefixes automatically with no control surface, so the cache read is
+		// the only observable evidence that it happened -- without it a caller
+		// cannot tell a cache hit from a full-price request.
+		if resp.Usage.PromptTokensDetails.CachedTokens > 0 {
+			usage.CacheReadInputTokens = int(resp.Usage.PromptTokensDetails.CachedTokens)
+		}
+
 		// Add reasoning tokens if available (for o1 models)
 		if resp.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
 			usage.ReasoningTokens = int(resp.Usage.CompletionTokensDetails.ReasoningTokens)

--- a/pkg/orchestration/transfer.go
+++ b/pkg/orchestration/transfer.go
@@ -1,0 +1,237 @@
+package orchestration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// TransferTool lets a model hand a conversation to another agent by calling a
+// tool, rather than by emitting a marker in its prose.
+//
+// The existing handoff mechanism parses free-form output:
+//
+//	regexp.MustCompile(`\[HANDOFF:([a-zA-Z0-9_-]+):([^\]]+)\]`)
+//
+// which requires the prompt to teach a bespoke syntax, breaks when the model
+// paraphrases or wraps the marker in a code fence, and cannot constrain the
+// target -- a hallucinated agent name is only discovered after the fact. A tool
+// call is structured, and the agent name can be constrained to an enum so the
+// model cannot invent one.
+//
+// Transfer is a request, not an execution. The tool records the decision and
+// returns; the caller runs the target agent. That keeps the depth guard, the
+// cycle check and usage accounting under the caller's control rather than
+// buried in a tool.
+type TransferTool struct {
+	registry     *AgentRegistry
+	descriptions map[string]string
+
+	mu        sync.Mutex
+	requested *TransferRequest
+}
+
+// TransferRequest is a model's decision to hand off.
+type TransferRequest struct {
+	// TargetAgentID is the agent to transfer to.
+	TargetAgentID string
+
+	// Reason is why, in the model's words. Worth keeping: it is the only
+	// explanation a human debugging a routing decision will have.
+	Reason string
+
+	// Query is what to ask the target agent.
+	Query string
+}
+
+// NewTransferTool creates a transfer tool over a registry.
+//
+// descriptions maps agent ID to a one-line summary of what that agent is for.
+// They are what the model routes on, so an agent with no description is
+// effectively unreachable.
+func NewTransferTool(registry *AgentRegistry, descriptions map[string]string) *TransferTool {
+	return &TransferTool{registry: registry, descriptions: descriptions}
+}
+
+// Name implements interfaces.Tool.
+func (t *TransferTool) Name() string { return "transfer_to_agent" }
+
+// Description implements interfaces.Tool.
+func (t *TransferTool) Description() string {
+	var b strings.Builder
+	b.WriteString("Transfer the conversation to a more suitable agent. ")
+	b.WriteString("Use this when another agent is better equipped to answer.\n\nAvailable agents:\n")
+
+	for _, id := range t.agentIDs() {
+		if desc := t.descriptions[id]; desc != "" {
+			fmt.Fprintf(&b, "- %s: %s\n", id, desc)
+		} else {
+			fmt.Fprintf(&b, "- %s\n", id)
+		}
+	}
+	return b.String()
+}
+
+// Parameters implements interfaces.Tool.
+func (t *TransferTool) Parameters() map[string]interfaces.ParameterSpec {
+	ids := t.agentIDs()
+	enum := make([]interface{}, 0, len(ids))
+	for _, id := range ids {
+		enum = append(enum, id)
+	}
+
+	spec := interfaces.ParameterSpec{
+		Type:        "string",
+		Description: "The agent to transfer to",
+		Required:    true,
+	}
+	// Constraining the target is the point. A free-form string invites a
+	// hallucinated agent name, which costs a whole turn to discover.
+	if len(enum) > 0 {
+		spec.Enum = enum
+	}
+
+	return map[string]interfaces.ParameterSpec{
+		"agent": spec,
+		"reason": {
+			Type:        "string",
+			Description: "Why this agent is better suited",
+			Required:    false,
+		},
+		"query": {
+			Type:        "string",
+			Description: "What to ask the target agent. Defaults to the current request.",
+			Required:    false,
+		},
+	}
+}
+
+// Run implements interfaces.Tool.
+func (t *TransferTool) Run(ctx context.Context, input string) (string, error) {
+	return t.Execute(ctx, input)
+}
+
+// Execute implements interfaces.Tool.
+func (t *TransferTool) Execute(_ context.Context, args string) (string, error) {
+	var params struct {
+		Agent  string `json:"agent"`
+		Reason string `json:"reason"`
+		Query  string `json:"query"`
+	}
+	if err := json.Unmarshal([]byte(args), &params); err != nil {
+		return "", fmt.Errorf("parsing transfer arguments: %w", err)
+	}
+
+	if params.Agent == "" {
+		return "A target agent is required. " + t.Description(), nil
+	}
+
+	if _, ok := t.registry.Get(params.Agent); !ok {
+		// Reported to the model rather than failing: listing the real options
+		// makes the next turn recoverable.
+		return fmt.Sprintf("There is no agent named %q. %s", params.Agent, t.Description()), nil
+	}
+
+	t.mu.Lock()
+	t.requested = &TransferRequest{
+		TargetAgentID: params.Agent,
+		Reason:        params.Reason,
+		Query:         params.Query,
+	}
+	t.mu.Unlock()
+
+	return fmt.Sprintf("Transferring to %q.", params.Agent), nil
+}
+
+// Requested returns the transfer the model asked for, if any, and clears it.
+//
+// Clearing on read means a handle reused across turns cannot replay a stale
+// decision from a previous turn.
+func (t *TransferTool) Requested() (*TransferRequest, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	req := t.requested
+	t.requested = nil
+	return req, req != nil
+}
+
+func (t *TransferTool) agentIDs() []string {
+	agents := t.registry.List()
+	ids := make([]string, 0, len(agents))
+	for id := range agents {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+var _ interfaces.Tool = (*TransferTool)(nil)
+
+// RunWithTransfers runs an agent and follows any transfers it requests.
+//
+// maxTransfers bounds the chain. Without a bound two agents can transfer to each
+// other indefinitely, each call costing a request -- the routing equivalent of
+// an infinite loop, and expensive.
+//
+// Returns the final answer and the chain of agent IDs that produced it, so a
+// caller can log or display how a request was routed.
+func RunWithTransfers(
+	ctx context.Context,
+	registry *AgentRegistry,
+	tool *TransferTool,
+	startAgentID string,
+	input string,
+	maxTransfers int,
+) (result string, chain []string, err error) {
+	if maxTransfers < 0 {
+		maxTransfers = 0
+	}
+
+	currentID := startAgentID
+	currentInput := input
+	visited := map[string]int{}
+
+	for transfers := 0; ; transfers++ {
+		current, ok := registry.Get(currentID)
+		if !ok {
+			return "", chain, fmt.Errorf("agent %q is not registered", currentID)
+		}
+		chain = append(chain, currentID)
+
+		// A repeat visit is not automatically wrong -- an agent may legitimately
+		// be returned to -- but an unbounded cycle is, so count it.
+		visited[currentID]++
+		if visited[currentID] > 2 {
+			return "", chain, fmt.Errorf("transfer loop: agent %q was reached %d times",
+				currentID, visited[currentID])
+		}
+
+		answer, runErr := current.Run(ctx, currentInput)
+		if runErr != nil {
+			return "", chain, runErr
+		}
+
+		req, requested := tool.Requested()
+		if !requested {
+			return answer, chain, nil
+		}
+
+		if transfers >= maxTransfers {
+			// Return what the last agent said rather than an error: the user
+			// asked a question, and a partial answer beats a failure.
+			return answer, chain, fmt.Errorf(
+				"transfer limit of %d reached; returning the last agent's answer", maxTransfers)
+		}
+
+		currentID = req.TargetAgentID
+		if req.Query != "" {
+			currentInput = req.Query
+		}
+	}
+}

--- a/pkg/orchestration/transfer_test.go
+++ b/pkg/orchestration/transfer_test.go
@@ -1,0 +1,258 @@
+package orchestration
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Ingenimax/agent-sdk-go/internal/testutil"
+	"github.com/Ingenimax/agent-sdk-go/pkg/agent"
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+func transferRegistry(t *testing.T) (*AgentRegistry, map[string]*testutil.FakeLLM) {
+	t.Helper()
+	reg := NewAgentRegistry()
+	llms := map[string]*testutil.FakeLLM{}
+
+	for _, name := range []string{"triage", "billing", "technical"} {
+		llm := &testutil.FakeLLM{DefaultResponse: name + " answered"}
+		a, err := agent.NewAgent(
+			agent.WithLLM(llm),
+			agent.WithName(name),
+			agent.WithRequirePlanApproval(false),
+		)
+		if err != nil {
+			t.Fatalf("NewAgent(%s) error = %v", name, err)
+		}
+		reg.Register(name, a)
+		llms[name] = llm
+	}
+	return reg, llms
+}
+
+func descriptions() map[string]string {
+	return map[string]string{
+		"triage":    "Route a request to the right specialist",
+		"billing":   "Answer invoicing and payment questions",
+		"technical": "Diagnose product faults",
+	}
+}
+
+// TestTransferTargetIsConstrainedToRealAgents is the concrete improvement over
+// the regex handoff.
+//
+// The previous mechanism parsed [HANDOFF:name:reason] out of prose, so nothing
+// stopped the model naming an agent that does not exist -- discovered only
+// after the fact. An enum makes it unrepresentable.
+func TestTransferTargetIsConstrainedToRealAgents(t *testing.T) {
+	reg, _ := transferRegistry(t)
+	tool := NewTransferTool(reg, descriptions())
+
+	spec := tool.Parameters()["agent"]
+	if len(spec.Enum) != 3 {
+		t.Fatalf("agent enum has %d entries, want 3", len(spec.Enum))
+	}
+
+	got := map[string]bool{}
+	for _, v := range spec.Enum {
+		got[v.(string)] = true
+	}
+	for _, want := range []string{"triage", "billing", "technical"} {
+		if !got[want] {
+			t.Errorf("enum missing %q", want)
+		}
+	}
+}
+
+func TestDescriptionListsAgentsAndTheirPurpose(t *testing.T) {
+	reg, _ := transferRegistry(t)
+	tool := NewTransferTool(reg, descriptions())
+
+	desc := tool.Description()
+	if !strings.Contains(desc, "billing") || !strings.Contains(desc, "invoicing") {
+		t.Errorf("description should carry each agent's purpose, since that is what "+
+			"the model routes on; got:\n%s", desc)
+	}
+}
+
+func TestExecuteRecordsTheRequestedTransfer(t *testing.T) {
+	reg, _ := transferRegistry(t)
+	tool := NewTransferTool(reg, descriptions())
+
+	args, _ := json.Marshal(map[string]string{
+		"agent":  "billing",
+		"reason": "this is an invoice question",
+		"query":  "why was I charged twice?",
+	})
+	out, err := tool.Execute(context.Background(), string(args))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(out, "billing") {
+		t.Errorf("result = %q, want it to confirm the target", out)
+	}
+
+	req, ok := tool.Requested()
+	if !ok {
+		t.Fatal("no transfer was recorded")
+	}
+	if req.TargetAgentID != "billing" {
+		t.Errorf("target = %q, want %q", req.TargetAgentID, "billing")
+	}
+	if req.Reason != "this is an invoice question" {
+		t.Errorf("reason = %q, want it preserved for debugging", req.Reason)
+	}
+	if req.Query != "why was I charged twice?" {
+		t.Errorf("query = %q", req.Query)
+	}
+}
+
+// TestRequestedClearsOnRead stops a handle reused across turns from replaying a
+// stale routing decision.
+func TestRequestedClearsOnRead(t *testing.T) {
+	reg, _ := transferRegistry(t)
+	tool := NewTransferTool(reg, descriptions())
+
+	args, _ := json.Marshal(map[string]string{"agent": "billing"})
+	_, _ = tool.Execute(context.Background(), string(args))
+
+	if _, ok := tool.Requested(); !ok {
+		t.Fatal("the first read should return the transfer")
+	}
+	if _, ok := tool.Requested(); ok {
+		t.Error("a second read returned a stale transfer; it must clear on read")
+	}
+}
+
+func TestUnknownTargetIsRecoverable(t *testing.T) {
+	reg, _ := transferRegistry(t)
+	tool := NewTransferTool(reg, descriptions())
+
+	args, _ := json.Marshal(map[string]string{"agent": "nonexistent"})
+	out, err := tool.Execute(context.Background(), string(args))
+	if err != nil {
+		t.Fatalf("an unknown target should not fail the run: %v", err)
+	}
+	if !strings.Contains(out, "billing") {
+		t.Error("the response should list the real agents so the turn is recoverable")
+	}
+	if _, ok := tool.Requested(); ok {
+		t.Error("an unknown target must not be recorded as a transfer")
+	}
+}
+
+func TestRunWithTransfersFollowsTheChain(t *testing.T) {
+	reg, llms := transferRegistry(t)
+	tool := NewTransferTool(reg, descriptions())
+
+	// triage transfers to billing on its first call.
+	var transferred bool
+	llms["triage"].GenerateFunc = func(context.Context, string, []interfaces.Tool) (string, error) {
+		if !transferred {
+			transferred = true
+			args, _ := json.Marshal(map[string]string{
+				"agent": "billing",
+				"query": "why was I charged twice?",
+			})
+			_, _ = tool.Execute(context.Background(), string(args))
+			return "handing off", nil
+		}
+		return "triage answered", nil
+	}
+
+	result, chain, err := RunWithTransfers(context.Background(), reg, tool,
+		"triage", "I have a question", 3)
+	if err != nil {
+		t.Fatalf("RunWithTransfers() error = %v", err)
+	}
+	if result != "billing answered" {
+		t.Errorf("result = %q, want the target agent's answer", result)
+	}
+	if len(chain) != 2 || chain[0] != "triage" || chain[1] != "billing" {
+		t.Errorf("chain = %v, want [triage billing]", chain)
+	}
+
+	// The transferred query should reach the target.
+	if prompts := llms["billing"].Prompts(); len(prompts) == 0 ||
+		!strings.Contains(prompts[0], "charged twice") {
+		t.Errorf("the target did not receive the transferred query; got %v", prompts)
+	}
+}
+
+func TestNoTransferReturnsTheFirstAnswer(t *testing.T) {
+	reg, _ := transferRegistry(t)
+	tool := NewTransferTool(reg, descriptions())
+
+	result, chain, err := RunWithTransfers(context.Background(), reg, tool,
+		"triage", "simple question", 3)
+	if err != nil {
+		t.Fatalf("RunWithTransfers() error = %v", err)
+	}
+	if result != "triage answered" {
+		t.Errorf("result = %q", result)
+	}
+	if len(chain) != 1 {
+		t.Errorf("chain = %v, want just the starting agent", chain)
+	}
+}
+
+// TestTransferLoopIsBounded guards the expensive failure: two agents handing a
+// request back and forth, each pass costing a request.
+func TestTransferLoopIsBounded(t *testing.T) {
+	reg, llms := transferRegistry(t)
+	tool := NewTransferTool(reg, descriptions())
+
+	// triage and billing bounce the request between them forever.
+	llms["triage"].GenerateFunc = func(context.Context, string, []interfaces.Tool) (string, error) {
+		args, _ := json.Marshal(map[string]string{"agent": "billing"})
+		_, _ = tool.Execute(context.Background(), string(args))
+		return "to billing", nil
+	}
+	llms["billing"].GenerateFunc = func(context.Context, string, []interfaces.Tool) (string, error) {
+		args, _ := json.Marshal(map[string]string{"agent": "triage"})
+		_, _ = tool.Execute(context.Background(), string(args))
+		return "to triage", nil
+	}
+
+	_, chain, err := RunWithTransfers(context.Background(), reg, tool,
+		"triage", "bounce me", 10)
+	if err == nil {
+		t.Fatal("an unbounded transfer loop should be reported")
+	}
+	if len(chain) > 6 {
+		t.Errorf("chain grew to %d hops before stopping: %v", len(chain), chain)
+	}
+}
+
+func TestTransferLimitReturnsTheLastAnswer(t *testing.T) {
+	reg, llms := transferRegistry(t)
+	tool := NewTransferTool(reg, descriptions())
+
+	llms["triage"].GenerateFunc = func(context.Context, string, []interfaces.Tool) (string, error) {
+		args, _ := json.Marshal(map[string]string{"agent": "billing"})
+		_, _ = tool.Execute(context.Background(), string(args))
+		return "triage says hand off", nil
+	}
+
+	result, _, err := RunWithTransfers(context.Background(), reg, tool,
+		"triage", "question", 0)
+	if err == nil {
+		t.Error("hitting the transfer limit should be reported")
+	}
+	if result != "triage says hand off" {
+		t.Errorf("result = %q, want the last agent's answer rather than nothing: "+
+			"a partial answer beats a failure", result)
+	}
+}
+
+func TestRunWithTransfersRejectsUnknownStart(t *testing.T) {
+	reg, _ := transferRegistry(t)
+	tool := NewTransferTool(reg, descriptions())
+
+	if _, _, err := RunWithTransfers(context.Background(), reg, tool,
+		"nope", "question", 3); err == nil {
+		t.Error("an unregistered starting agent should be an error")
+	}
+}

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -1,0 +1,467 @@
+// Package run gives an agent run an identity, a registry and a cancel switch.
+//
+// Agent.Run is synchronous and anonymous: it returns a string and there is no
+// handle on the work while it is in flight. Nothing can ask what is running,
+// attach to it, or stop one specific run. The only per-run object in the SDK is
+// an unexported usage tracker living in a context value, which dies with the
+// stack frame.
+//
+// This package adds the missing layer, and deliberately nothing more:
+//
+//   - a RunID minted per run;
+//   - a Handle to await the result, observe status, or cancel;
+//   - a Manager that can list live runs and cancel one by ID.
+//
+// # Relationship to pkg/task
+//
+// pkg/task is a task *lifecycle* service: create a task, plan it, have a human
+// approve the plan, log against it. It concerns work a person tracks. This
+// package concerns a single agent invocation that is in flight right now. They
+// are not alternatives, and neither is built on the other.
+package run
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// ErrNotFound is returned when no run matches an ID.
+var ErrNotFound = errors.New("run not found")
+
+// Status is the lifecycle state of a run.
+type Status string
+
+const (
+	// StatusRunning means the run is in flight.
+	StatusRunning Status = "running"
+	// StatusSucceeded means the run produced a result.
+	StatusSucceeded Status = "succeeded"
+	// StatusFailed means the run returned an error.
+	StatusFailed Status = "failed"
+	// StatusCanceled means the run was cancelled before completing.
+	StatusCanceled Status = "canceled"
+)
+
+// Terminal reports whether a status is final.
+func (s Status) Terminal() bool {
+	return s == StatusSucceeded || s == StatusFailed || s == StatusCanceled
+}
+
+// Agent is the subset of an agent this package needs.
+//
+// Declared here rather than imported so pkg/run does not depend on pkg/agent,
+// which keeps the dependency pointing one way and lets callers wrap or fake an
+// agent freely.
+type Agent interface {
+	Run(ctx context.Context, input string) (string, error)
+	GetName() string
+}
+
+// StreamingAgent is implemented by agents that can stream.
+type StreamingAgent interface {
+	Agent
+	RunStream(ctx context.Context, input string) (<-chan interfaces.AgentStreamEvent, error)
+}
+
+// Info is a point-in-time snapshot of a run.
+type Info struct {
+	ID        string
+	AgentName string
+	Input     string
+	Status    Status
+	StartedAt time.Time
+	EndedAt   time.Time
+	Err       error
+}
+
+// Duration returns how long the run took, or how long it has been running.
+func (i Info) Duration() time.Duration {
+	if i.EndedAt.IsZero() {
+		return time.Since(i.StartedAt)
+	}
+	return i.EndedAt.Sub(i.StartedAt)
+}
+
+// Handle is a live reference to one run.
+type Handle struct {
+	id        string
+	agentName string
+	input     string
+
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu        sync.Mutex
+	status    Status
+	result    string
+	err       error
+	startedAt time.Time
+	endedAt   time.Time
+
+	events <-chan interfaces.AgentStreamEvent
+}
+
+// ID returns the run's identifier.
+func (h *Handle) ID() string { return h.id }
+
+// Info returns a snapshot of the run's current state.
+func (h *Handle) Info() Info {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return Info{
+		ID:        h.id,
+		AgentName: h.agentName,
+		Input:     h.input,
+		Status:    h.status,
+		StartedAt: h.startedAt,
+		EndedAt:   h.endedAt,
+		Err:       h.err,
+	}
+}
+
+// Done returns a channel closed when the run reaches a terminal state.
+func (h *Handle) Done() <-chan struct{} { return h.done }
+
+// Events returns the run's stream, or nil if it was not started with Stream.
+//
+// The channel is closed when the run finishes.
+func (h *Handle) Events() <-chan interfaces.AgentStreamEvent { return h.events }
+
+// Wait blocks until the run finishes and returns its result.
+//
+// Waiting respects the caller's own context: a caller giving up does not cancel
+// the run, which continues in the background. Use Cancel to stop it.
+func (h *Handle) Wait(ctx context.Context) (string, error) {
+	select {
+	case <-h.done:
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		return h.result, h.err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// Cancel stops the run. It is safe to call more than once, and on a run that
+// has already finished.
+func (h *Handle) Cancel() {
+	h.cancel()
+}
+
+func (h *Handle) finish(status Status, result string, err error) {
+	h.mu.Lock()
+	if h.status.Terminal() {
+		h.mu.Unlock()
+		return
+	}
+	h.status = status
+	h.result = result
+	h.err = err
+	h.endedAt = time.Now()
+	h.mu.Unlock()
+
+	close(h.done)
+}
+
+// Manager starts runs and keeps track of the ones in flight.
+//
+// The zero value is not usable; call NewManager.
+type Manager struct {
+	mu   sync.RWMutex
+	runs map[string]*Handle
+
+	// retain bounds how many finished runs stay listable. Without a bound a
+	// long-lived service accumulates every run it has ever executed.
+	retain   int
+	finished []string
+}
+
+// ManagerOption configures a Manager.
+type ManagerOption func(*Manager)
+
+// WithRetainedRuns sets how many finished runs remain listable. Defaults to 100.
+//
+// A bound matters: a registry that keeps every run forever is a memory leak in
+// any service that stays up.
+func WithRetainedRuns(n int) ManagerOption {
+	return func(m *Manager) {
+		if n >= 0 {
+			m.retain = n
+		}
+	}
+}
+
+// NewManager creates a run manager.
+func NewManager(options ...ManagerOption) *Manager {
+	m := &Manager{
+		runs:   make(map[string]*Handle),
+		retain: 100,
+	}
+	for _, option := range options {
+		option(m)
+	}
+	return m
+}
+
+// StartOption configures a single run.
+type StartOption func(*startConfig)
+
+type startConfig struct {
+	timeout  time.Duration
+	detached bool
+}
+
+// WithTimeout bounds the run's duration.
+func WithTimeout(d time.Duration) StartOption {
+	return func(c *startConfig) { c.timeout = d }
+}
+
+// WithDetached runs independently of the caller's context, so the run survives
+// the request that started it.
+//
+// Without this a background run started inside an HTTP handler dies when the
+// client disconnects, which is rarely what "background" is meant to mean. With
+// it, the only ways to stop the run are Cancel or a timeout -- so a timeout is
+// strongly advised alongside it.
+func WithDetached() StartOption {
+	return func(c *startConfig) { c.detached = true }
+}
+
+// Start runs an agent in the background and returns immediately.
+func (m *Manager) Start(ctx context.Context, agent Agent, input string, options ...StartOption) *Handle {
+	h, runCtx := m.begin(ctx, agent, input, options...)
+
+	go func() {
+		result, err := agent.Run(runCtx, input)
+		m.complete(h, runCtx, result, err)
+	}()
+
+	return h
+}
+
+// Stream runs an agent in the background and exposes its events.
+//
+// The agent must implement StreamingAgent; otherwise the returned handle
+// finishes immediately with an error.
+func (m *Manager) Stream(ctx context.Context, agent Agent, input string, options ...StartOption) *Handle {
+	h, runCtx := m.begin(ctx, agent, input, options...)
+
+	streamer, ok := agent.(StreamingAgent)
+	if !ok {
+		h.finish(StatusFailed, "", fmt.Errorf("agent %q does not support streaming", agent.GetName()))
+		m.retire(h.id)
+		return h
+	}
+
+	source, err := streamer.RunStream(runCtx, input)
+	if err != nil {
+		h.finish(StatusFailed, "", err)
+		m.retire(h.id)
+		return h
+	}
+
+	// Re-broadcast so the handle owns a channel it can close on completion,
+	// and so content can be accumulated into the run's result.
+	out := make(chan interfaces.AgentStreamEvent, 32)
+	h.events = out
+
+	go func() {
+		defer close(out)
+
+		var content string
+		var streamErr error
+
+		for event := range source {
+			if event.Type == interfaces.AgentEventContent {
+				content += event.Content
+			}
+			if event.Error != nil {
+				streamErr = event.Error
+			}
+			select {
+			case out <- event:
+			case <-runCtx.Done():
+				m.complete(h, runCtx, content, runCtx.Err())
+				return
+			}
+		}
+
+		m.complete(h, runCtx, content, streamErr)
+	}()
+
+	return h
+}
+
+func (m *Manager) begin(ctx context.Context, agent Agent, input string, options ...StartOption) (*Handle, context.Context) {
+	cfg := &startConfig{}
+	for _, option := range options {
+		option(cfg)
+	}
+
+	// A detached run must not inherit cancellation from the caller, or
+	// "background" lasts only as long as the request that started it.
+	base := ctx
+	if cfg.detached {
+		base = context.WithoutCancel(ctx)
+	}
+
+	var runCtx context.Context
+	var cancel context.CancelFunc
+	if cfg.timeout > 0 {
+		runCtx, cancel = context.WithTimeout(base, cfg.timeout)
+	} else {
+		runCtx, cancel = context.WithCancel(base)
+	}
+
+	h := &Handle{
+		id:        newID(),
+		agentName: agent.GetName(),
+		input:     input,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+		status:    StatusRunning,
+		startedAt: time.Now(),
+	}
+	runCtx = WithRunID(runCtx, h.id)
+
+	m.mu.Lock()
+	m.runs[h.id] = h
+	m.mu.Unlock()
+
+	return h, runCtx
+}
+
+func (m *Manager) complete(h *Handle, runCtx context.Context, result string, err error) {
+	status := StatusSucceeded
+	switch {
+	case errors.Is(runCtx.Err(), context.Canceled), errors.Is(runCtx.Err(), context.DeadlineExceeded):
+		status = StatusCanceled
+		if err == nil {
+			err = runCtx.Err()
+		}
+	case err != nil:
+		status = StatusFailed
+	}
+
+	h.finish(status, result, err)
+	h.cancel() // release the context's resources
+	m.retire(h.id)
+}
+
+// retire moves a finished run into the bounded retention list.
+func (m *Manager) retire(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.retain == 0 {
+		delete(m.runs, id)
+		return
+	}
+
+	m.finished = append(m.finished, id)
+	for len(m.finished) > m.retain {
+		delete(m.runs, m.finished[0])
+		m.finished = m.finished[1:]
+	}
+}
+
+// Get returns the handle for a run ID.
+func (m *Manager) Get(id string) (*Handle, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	h, ok := m.runs[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrNotFound, id)
+	}
+	return h, nil
+}
+
+// List returns a snapshot of every known run, in-flight and retained.
+func (m *Manager) List() []Info {
+	m.mu.RLock()
+	handles := make([]*Handle, 0, len(m.runs))
+	for _, h := range m.runs {
+		handles = append(handles, h)
+	}
+	m.mu.RUnlock()
+
+	infos := make([]Info, 0, len(handles))
+	for _, h := range handles {
+		infos = append(infos, h.Info())
+	}
+	return infos
+}
+
+// Active returns only the runs still in flight.
+func (m *Manager) Active() []Info {
+	var active []Info
+	for _, info := range m.List() {
+		if !info.Status.Terminal() {
+			active = append(active, info)
+		}
+	}
+	return active
+}
+
+// Cancel stops the run with the given ID.
+func (m *Manager) Cancel(id string) error {
+	h, err := m.Get(id)
+	if err != nil {
+		return err
+	}
+	h.Cancel()
+	return nil
+}
+
+// CancelAll stops every run still in flight and returns how many it signalled.
+func (m *Manager) CancelAll() int {
+	m.mu.RLock()
+	handles := make([]*Handle, 0, len(m.runs))
+	for _, h := range m.runs {
+		handles = append(handles, h)
+	}
+	m.mu.RUnlock()
+
+	var n int
+	for _, h := range handles {
+		if !h.Info().Status.Terminal() {
+			h.Cancel()
+			n++
+		}
+	}
+	return n
+}
+
+type contextKey string
+
+const runIDKey contextKey = "run_id"
+
+// WithRunID puts a run ID on the context.
+func WithRunID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, runIDKey, id)
+}
+
+// FromContext returns the run ID on the context, if any.
+//
+// It returns the ID rather than the Handle deliberately: a Handle is mutable
+// and reachable from arbitrary tool code, including MCP tools backed by remote
+// processes, which could then mark a run succeeded or forge its result.
+func FromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(runIDKey).(string)
+	return id, ok
+}
+
+func newID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("run_%d", time.Now().UnixNano())
+	}
+	return "run_" + hex.EncodeToString(b[:])
+}

--- a/pkg/run/run_test.go
+++ b/pkg/run/run_test.go
@@ -1,0 +1,348 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// blockingAgent runs until released or its context ends.
+type blockingAgent struct {
+	name    string
+	release chan struct{}
+	started chan struct{}
+	reply   string
+	err     error
+
+	mu     sync.Mutex
+	ctxErr error
+}
+
+func newBlockingAgent(name string) *blockingAgent {
+	return &blockingAgent{
+		name:    name,
+		release: make(chan struct{}),
+		started: make(chan struct{}, 1),
+		reply:   "done",
+	}
+}
+
+func (a *blockingAgent) GetName() string { return a.name }
+
+func (a *blockingAgent) Run(ctx context.Context, _ string) (string, error) {
+	select {
+	case a.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-a.release:
+		return a.reply, a.err
+	case <-ctx.Done():
+		a.mu.Lock()
+		a.ctxErr = ctx.Err()
+		a.mu.Unlock()
+		return "", ctx.Err()
+	}
+}
+
+func (a *blockingAgent) RunStream(ctx context.Context, input string) (<-chan interfaces.AgentStreamEvent, error) {
+	ch := make(chan interfaces.AgentStreamEvent, 4)
+	go func() {
+		defer close(ch)
+		result, err := a.Run(ctx, input)
+		if err != nil {
+			ch <- interfaces.AgentStreamEvent{Type: interfaces.AgentEventError, Error: err}
+			return
+		}
+		ch <- interfaces.AgentStreamEvent{Type: interfaces.AgentEventContent, Content: result}
+		ch <- interfaces.AgentStreamEvent{Type: interfaces.AgentEventComplete}
+	}()
+	return ch, nil
+}
+
+func (a *blockingAgent) observedCtxErr() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.ctxErr
+}
+
+func TestStartReturnsImmediatelyAndWaitDelivers(t *testing.T) {
+	m := NewManager()
+	a := newBlockingAgent("worker")
+
+	h := m.Start(context.Background(), a, "go")
+
+	// Start must not block on the agent.
+	select {
+	case <-a.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the agent never started")
+	}
+	if got := h.Info().Status; got != StatusRunning {
+		t.Errorf("status = %q, want %q while in flight", got, StatusRunning)
+	}
+
+	close(a.release)
+
+	result, err := h.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if result != "done" {
+		t.Errorf("result = %q, want %q", result, "done")
+	}
+	if got := h.Info().Status; got != StatusSucceeded {
+		t.Errorf("status = %q, want %q", got, StatusSucceeded)
+	}
+}
+
+// TestCancelByIDStopsTheRun is the capability the SDK had no form of: nothing
+// could stop one specific run.
+func TestCancelByIDStopsTheRun(t *testing.T) {
+	m := NewManager()
+	a := newBlockingAgent("worker")
+
+	h := m.Start(context.Background(), a, "go")
+	<-a.started
+
+	if err := m.Cancel(h.ID()); err != nil {
+		t.Fatalf("Cancel() error = %v", err)
+	}
+
+	select {
+	case <-h.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("the run did not finish after being cancelled")
+	}
+
+	if got := h.Info().Status; got != StatusCanceled {
+		t.Errorf("status = %q, want %q", got, StatusCanceled)
+	}
+	if !errors.Is(a.observedCtxErr(), context.Canceled) {
+		t.Errorf("the agent's context ended with %v, want context.Canceled", a.observedCtxErr())
+	}
+}
+
+func TestCancelUnknownRunIsAnError(t *testing.T) {
+	m := NewManager()
+	if err := m.Cancel("run_nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Cancel(unknown) error = %v, want ErrNotFound", err)
+	}
+}
+
+// TestDetachedRunSurvivesTheCallersContext guards the property that makes a
+// background run useful: it must outlive the request that started it.
+func TestDetachedRunSurvivesTheCallersContext(t *testing.T) {
+	m := NewManager()
+	a := newBlockingAgent("worker")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h := m.Start(ctx, a, "go", WithDetached(), WithTimeout(30*time.Second))
+	<-a.started
+
+	// The caller gives up -- as an HTTP handler returning would.
+	cancel()
+
+	// The run must still be in flight.
+	time.Sleep(200 * time.Millisecond)
+	if got := h.Info().Status; got != StatusRunning {
+		t.Fatalf("status = %q after the caller's context was cancelled, want %q: "+
+			"a detached run must outlive the request that started it", got, StatusRunning)
+	}
+
+	close(a.release)
+	if _, err := h.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+}
+
+// TestAttachedRunDiesWithTheCaller is the complementary default: without
+// WithDetached, cancelling the caller cancels the run.
+func TestAttachedRunDiesWithTheCaller(t *testing.T) {
+	m := NewManager()
+	a := newBlockingAgent("worker")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h := m.Start(ctx, a, "go")
+	<-a.started
+
+	cancel()
+
+	select {
+	case <-h.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("an attached run did not stop when its caller was cancelled")
+	}
+	if got := h.Info().Status; got != StatusCanceled {
+		t.Errorf("status = %q, want %q", got, StatusCanceled)
+	}
+}
+
+func TestTimeoutCancelsTheRun(t *testing.T) {
+	m := NewManager()
+	a := newBlockingAgent("worker")
+
+	h := m.Start(context.Background(), a, "go", WithTimeout(150*time.Millisecond))
+
+	select {
+	case <-h.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("the run did not stop at its timeout")
+	}
+	if got := h.Info().Status; got != StatusCanceled {
+		t.Errorf("status = %q, want %q", got, StatusCanceled)
+	}
+}
+
+func TestListAndActiveReflectState(t *testing.T) {
+	m := NewManager()
+	a1 := newBlockingAgent("one")
+	a2 := newBlockingAgent("two")
+
+	h1 := m.Start(context.Background(), a1, "go")
+	h2 := m.Start(context.Background(), a2, "go")
+	<-a1.started
+	<-a2.started
+
+	if got := len(m.Active()); got != 2 {
+		t.Errorf("Active() = %d runs, want 2", got)
+	}
+
+	close(a1.release)
+	<-h1.Done()
+
+	if got := len(m.Active()); got != 1 {
+		t.Errorf("Active() = %d runs after one finished, want 1", got)
+	}
+	if got := len(m.List()); got != 2 {
+		t.Errorf("List() = %d runs, want 2 (finished runs are retained)", got)
+	}
+
+	close(a2.release)
+	<-h2.Done()
+}
+
+// TestRetentionIsBounded guards against the registry becoming a memory leak in
+// a long-lived service.
+func TestRetentionIsBounded(t *testing.T) {
+	m := NewManager(WithRetainedRuns(3))
+
+	for i := 0; i < 10; i++ {
+		a := newBlockingAgent("worker")
+		close(a.release)
+		h := m.Start(context.Background(), a, "go")
+		<-h.Done()
+	}
+
+	if got := len(m.List()); got > 3 {
+		t.Errorf("List() = %d runs, want at most 3: finished runs must not accumulate", got)
+	}
+}
+
+func TestRunIDIsOnTheContext(t *testing.T) {
+	m := NewManager()
+
+	var seen string
+	var mu sync.Mutex
+	a := &funcAgent{name: "worker", fn: func(ctx context.Context, _ string) (string, error) {
+		id, _ := FromContext(ctx)
+		mu.Lock()
+		seen = id
+		mu.Unlock()
+		return "ok", nil
+	}}
+
+	h := m.Start(context.Background(), a, "go")
+	if _, err := h.Wait(context.Background()); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if seen == "" {
+		t.Error("no run ID reached the agent's context")
+	}
+	if seen != h.ID() {
+		t.Errorf("context run ID = %q, want the handle's ID %q", seen, h.ID())
+	}
+}
+
+func TestStreamDeliversEventsAndResult(t *testing.T) {
+	m := NewManager()
+	a := newBlockingAgent("worker")
+	close(a.release)
+
+	h := m.Stream(context.Background(), a, "go")
+
+	var content string
+	for event := range h.Events() {
+		if event.Type == interfaces.AgentEventContent {
+			content += event.Content
+		}
+	}
+
+	result, err := h.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if content != "done" {
+		t.Errorf("streamed content = %q, want %q", content, "done")
+	}
+	if result != "done" {
+		t.Errorf("result = %q, want the accumulated content", result)
+	}
+}
+
+func TestStreamOnNonStreamingAgentFails(t *testing.T) {
+	m := NewManager()
+	a := &funcAgent{name: "plain", fn: func(context.Context, string) (string, error) {
+		return "ok", nil
+	}}
+
+	h := m.Stream(context.Background(), a, "go")
+	if _, err := h.Wait(context.Background()); err == nil {
+		t.Error("Stream on a non-streaming agent should fail")
+	}
+	if got := h.Info().Status; got != StatusFailed {
+		t.Errorf("status = %q, want %q", got, StatusFailed)
+	}
+}
+
+func TestCancelAllStopsEveryLiveRun(t *testing.T) {
+	m := NewManager()
+	agents := make([]*blockingAgent, 3)
+	handles := make([]*Handle, 3)
+
+	for i := range agents {
+		agents[i] = newBlockingAgent("worker")
+		handles[i] = m.Start(context.Background(), agents[i], "go")
+		<-agents[i].started
+	}
+
+	if got := m.CancelAll(); got != 3 {
+		t.Errorf("CancelAll() signalled %d runs, want 3", got)
+	}
+
+	for _, h := range handles {
+		select {
+		case <-h.Done():
+		case <-time.After(5 * time.Second):
+			t.Fatal("a run did not stop after CancelAll")
+		}
+	}
+}
+
+// funcAgent is a minimal Agent backed by a function.
+type funcAgent struct {
+	name string
+	fn   func(context.Context, string) (string, error)
+}
+
+func (a *funcAgent) GetName() string { return a.name }
+func (a *funcAgent) Run(ctx context.Context, input string) (string, error) {
+	return a.fn(ctx, input)
+}

--- a/pkg/session/manager.go
+++ b/pkg/session/manager.go
@@ -1,0 +1,176 @@
+package session
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/memory"
+	"github.com/Ingenimax/agent-sdk-go/pkg/multitenancy"
+)
+
+// Manager creates and resolves sessions, and stamps the identity that memory
+// scoping requires onto a context.
+//
+// This is the piece that makes sessions useful rather than decorative. Memory
+// derives its scope key from multitenancy.GetOrgID and memory.GetConversationID
+// and hard-fails when either is missing -- which is why a scheduled or
+// background run, having no inbound request to inherit from, could not write to
+// memory at all. Resolve produces a context carrying both.
+type Manager struct {
+	store   Store
+	appName string
+}
+
+// ManagerOption configures a Manager.
+type ManagerOption func(*Manager)
+
+// WithAppName sets the application name used to scope "app:" state.
+func WithAppName(name string) ManagerOption {
+	return func(m *Manager) { m.appName = name }
+}
+
+// NewManager creates a session manager over a store.
+func NewManager(store Store, options ...ManagerOption) *Manager {
+	m := &Manager{store: store}
+	for _, option := range options {
+		option(m)
+	}
+	return m
+}
+
+// Create starts a new session.
+func (m *Manager) Create(ctx context.Context, orgID, userID string) (*Session, error) {
+	s := &Session{
+		ID:        NewID(),
+		OrgID:     orgID,
+		UserID:    userID,
+		AppName:   m.appName,
+		State:     map[string]any{},
+		CreatedAt: time.Now(),
+	}
+	if err := m.store.Create(ctx, s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Get returns an existing session.
+func (m *Manager) Get(ctx context.Context, orgID, id string) (*Session, error) {
+	return m.store.Get(ctx, orgID, id)
+}
+
+// Resume returns an existing session and a context scoped to it, ready to hand
+// to an agent.
+func (m *Manager) Resume(ctx context.Context, orgID, id string) (*Session, context.Context, error) {
+	s, err := m.store.Get(ctx, orgID, id)
+	if err != nil {
+		return nil, ctx, err
+	}
+	return s, m.Bind(ctx, s), nil
+}
+
+// Bind stamps a session's identity onto a context so memory can scope to it.
+//
+// Call this before handing the context to an agent. Without it an agent with
+// memory configured fails its first turn, because getConversationID requires
+// both an org ID and a conversation ID.
+func (m *Manager) Bind(ctx context.Context, s *Session) context.Context {
+	if s == nil {
+		return ctx
+	}
+	if s.OrgID != "" {
+		ctx = multitenancy.WithOrgID(ctx, s.OrgID)
+	}
+	return memory.WithConversationID(ctx, s.ID)
+}
+
+// Save persists changes to a session.
+func (m *Manager) Save(ctx context.Context, s *Session) error {
+	return m.store.Update(ctx, s)
+}
+
+// List returns sessions matching the filter.
+func (m *Manager) List(ctx context.Context, filter Filter) ([]*Session, error) {
+	return m.store.List(ctx, filter)
+}
+
+// Delete removes a session.
+func (m *Manager) Delete(ctx context.Context, orgID, id string) error {
+	return m.store.Delete(ctx, orgID, id)
+}
+
+// Fork creates a new session seeded with another's state.
+//
+// The transcript is not copied: sessions reference messages by conversation ID
+// rather than owning them, so a fork starts a fresh conversation carrying the
+// parent's accumulated state. The parent is recorded under "forked_from".
+func (m *Manager) Fork(ctx context.Context, orgID, id string) (*Session, error) {
+	parent, err := m.store.Get(ctx, orgID, id)
+	if err != nil {
+		return nil, err
+	}
+
+	child := parent.Clone()
+	child.ID = NewID()
+	child.CreatedAt = time.Now()
+	child.UpdatedAt = time.Time{}
+	child.MessageCount = 0
+	child.TokenTotal = 0
+	child.Set("forked_from", parent.ID)
+
+	if err := m.store.Create(ctx, child); err != nil {
+		return nil, err
+	}
+	return child, nil
+}
+
+// Touch records activity on a session: it refreshes UpdatedAt, adds to the
+// message and token counters, and derives a title from the first message if the
+// session does not have one yet.
+func (m *Manager) Touch(ctx context.Context, s *Session, messages, tokens int, firstMessage string) error {
+	s.MessageCount += messages
+	s.TokenTotal += tokens
+
+	if s.Title == "" && firstMessage != "" {
+		s.Title = DeriveTitle(firstMessage)
+	}
+
+	return m.store.Update(ctx, s)
+}
+
+// DeriveTitle produces a short label from a message.
+//
+// Kept deliberately dumb -- truncation on a word boundary, no model call. A
+// title is a listing convenience, and spending a model round trip (and its
+// latency, cost and failure mode) on one is not a good trade.
+func DeriveTitle(message string) string {
+	const maxLen = 60
+
+	title := strings.TrimSpace(strings.ReplaceAll(message, "\n", " "))
+	for strings.Contains(title, "  ") {
+		title = strings.ReplaceAll(title, "  ", " ")
+	}
+
+	if len(title) <= maxLen {
+		return title
+	}
+
+	truncated := title[:maxLen]
+	if idx := strings.LastIndex(truncated, " "); idx > maxLen/2 {
+		truncated = truncated[:idx]
+	}
+	return truncated + "…"
+}
+
+// NewID mints a session ID.
+func NewID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("sess_%d", time.Now().UnixNano())
+	}
+	return "sess_" + hex.EncodeToString(b[:])
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1,0 +1,373 @@
+// Package session gives a conversation a durable identity, metadata and
+// scoped state.
+//
+// Scoping in the SDK is ambient: memory derives an "orgID:conversationID" key
+// from the context and hard-fails if either is missing. That is enough to
+// isolate transcripts and no more. There is no object describing a
+// conversation, nothing to list with titles and timestamps, nowhere to keep a
+// fact that should outlive one turn, and no way to resume by ID with anything
+// other than a bare transcript.
+//
+// A Session supplies that. It deliberately does NOT own the transcript:
+// pkg/memory already stores messages, keyed by the same conversation ID a
+// Session is identified by. Duplicating messages here would create two sources
+// of truth for the same data.
+//
+//	Session.ID == the conversation ID used by pkg/memory
+//
+// # State scoping
+//
+// State keys are scoped by prefix, following the model Google's ADK uses:
+//
+//	"user:"   shared across every session belonging to one user
+//	"app:"    shared across every session in the application
+//	"temp:"   never persisted; dropped on save
+//	(none)    private to this session
+//
+// The prefixes are resolved at the storage layer, so a caller reads and writes
+// one flat namespace.
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrNotFound is returned when no session matches an ID.
+var ErrNotFound = errors.New("session not found")
+
+// State key prefixes.
+const (
+	// UserPrefix scopes a key to the user, across all their sessions.
+	UserPrefix = "user:"
+	// AppPrefix scopes a key to the application, across all users.
+	AppPrefix = "app:"
+	// TempPrefix marks a key as never persisted.
+	TempPrefix = "temp:"
+)
+
+// Session is one conversation.
+type Session struct {
+	// ID is the conversation ID. It is the same value pkg/memory scopes the
+	// transcript by, so a session and its messages are never out of step.
+	ID string
+
+	// OrgID is the owning organization, matching pkg/multitenancy.
+	OrgID string
+
+	// UserID identifies the end user, and scopes "user:" state.
+	UserID string
+
+	// AppName scopes "app:" state. Optional.
+	AppName string
+
+	// Title is a human-readable label, usually derived from the first message.
+	Title string
+
+	// State is the session's scoped key-value store. Read it through Get and
+	// write it through Set so prefixes are handled consistently.
+	State map[string]any
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	// MessageCount and TokenTotal are denormalised counters, maintained by the
+	// caller. They exist so a session list can show useful numbers without
+	// loading every transcript.
+	MessageCount int
+	TokenTotal   int
+}
+
+// Get reads a state key.
+func (s *Session) Get(key string) (any, bool) {
+	if s.State == nil {
+		return nil, false
+	}
+	v, ok := s.State[key]
+	return v, ok
+}
+
+// GetString reads a state key as a string.
+func (s *Session) GetString(key string) string {
+	v, ok := s.Get(key)
+	if !ok {
+		return ""
+	}
+	str, _ := v.(string)
+	return str
+}
+
+// Set writes a state key. Prefixes determine how far the value is shared; see
+// the package documentation.
+func (s *Session) Set(key string, value any) {
+	if s.State == nil {
+		s.State = map[string]any{}
+	}
+	s.State[key] = value
+}
+
+// Delete removes a state key.
+func (s *Session) Delete(key string) {
+	delete(s.State, key)
+}
+
+// Clone returns a deep copy, so a caller cannot mutate a store's internals
+// through a returned session.
+func (s *Session) Clone() *Session {
+	if s == nil {
+		return nil
+	}
+	clone := *s
+	clone.State = make(map[string]any, len(s.State))
+	for k, v := range s.State {
+		clone.State[k] = v
+	}
+	return &clone
+}
+
+// Filter narrows a session listing.
+type Filter struct {
+	OrgID  string
+	UserID string
+
+	// Limit caps the number of sessions returned. Zero means no limit.
+	Limit int
+}
+
+// Store persists sessions.
+//
+// Implementations must treat state prefixes as described in the package
+// documentation: "temp:" keys are dropped on save, and "user:"/"app:" keys are
+// shared across the sessions in that scope rather than copied into each.
+type Store interface {
+	// Create stores a new session. It returns an error if the ID already exists.
+	Create(ctx context.Context, s *Session) error
+
+	// Get returns a session by ID, with shared state merged in.
+	Get(ctx context.Context, orgID, id string) (*Session, error)
+
+	// Update replaces a session's mutable fields.
+	Update(ctx context.Context, s *Session) error
+
+	// Delete removes a session and its private state.
+	Delete(ctx context.Context, orgID, id string) error
+
+	// List returns sessions matching the filter, most recently updated first.
+	// The returned sessions carry metadata but not state.
+	List(ctx context.Context, filter Filter) ([]*Session, error)
+}
+
+// splitState separates a flat state map into the three persisted scopes,
+// discarding "temp:" keys.
+func splitState(state map[string]any) (private, user, app map[string]any) {
+	private = map[string]any{}
+	user = map[string]any{}
+	app = map[string]any{}
+
+	for k, v := range state {
+		switch {
+		case strings.HasPrefix(k, TempPrefix):
+			// Deliberately dropped: temp state exists for the duration of one
+			// invocation and must never reach storage.
+		case strings.HasPrefix(k, UserPrefix):
+			user[k] = v
+		case strings.HasPrefix(k, AppPrefix):
+			app[k] = v
+		default:
+			private[k] = v
+		}
+	}
+	return private, user, app
+}
+
+// mergeState recombines the scopes into the flat namespace callers see.
+func mergeState(private, user, app map[string]any) map[string]any {
+	merged := make(map[string]any, len(private)+len(user)+len(app))
+	for k, v := range app {
+		merged[k] = v
+	}
+	for k, v := range user {
+		merged[k] = v
+	}
+	for k, v := range private {
+		merged[k] = v
+	}
+	return merged
+}
+
+// InMemoryStore keeps sessions in process. Suitable for tests, single-process
+// deployments and local development.
+type InMemoryStore struct {
+	mu       sync.RWMutex
+	sessions map[string]*Session       // keyed orgID/id
+	private  map[string]map[string]any // keyed orgID/id
+	user     map[string]map[string]any // keyed orgID/userID
+	app      map[string]map[string]any // keyed appName
+}
+
+// NewInMemoryStore creates an in-process session store.
+func NewInMemoryStore() *InMemoryStore {
+	return &InMemoryStore{
+		sessions: map[string]*Session{},
+		private:  map[string]map[string]any{},
+		user:     map[string]map[string]any{},
+		app:      map[string]map[string]any{},
+	}
+}
+
+func sessionKey(orgID, id string) string  { return orgID + "/" + id }
+func userKey(orgID, userID string) string { return orgID + "/" + userID }
+
+// Create implements Store.
+func (s *InMemoryStore) Create(_ context.Context, sess *Session) error {
+	if sess == nil || sess.ID == "" {
+		return fmt.Errorf("session requires an ID")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := sessionKey(sess.OrgID, sess.ID)
+	if _, exists := s.sessions[key]; exists {
+		return fmt.Errorf("session %s already exists", sess.ID)
+	}
+
+	now := time.Now()
+	stored := sess.Clone()
+	if stored.CreatedAt.IsZero() {
+		stored.CreatedAt = now
+	}
+	stored.UpdatedAt = now
+
+	private, user, app := splitState(stored.State)
+	stored.State = nil
+
+	s.sessions[key] = stored
+	s.private[key] = private
+	s.mergeShared(stored, user, app)
+
+	return nil
+}
+
+// Get implements Store.
+func (s *InMemoryStore) Get(_ context.Context, orgID, id string) (*Session, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	key := sessionKey(orgID, id)
+	stored, ok := s.sessions[key]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrNotFound, id)
+	}
+
+	out := stored.Clone()
+	out.State = mergeState(
+		s.private[key],
+		s.user[userKey(orgID, stored.UserID)],
+		s.app[stored.AppName],
+	)
+	return out, nil
+}
+
+// Update implements Store.
+func (s *InMemoryStore) Update(_ context.Context, sess *Session) error {
+	if sess == nil || sess.ID == "" {
+		return fmt.Errorf("session requires an ID")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := sessionKey(sess.OrgID, sess.ID)
+	existing, ok := s.sessions[key]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrNotFound, sess.ID)
+	}
+
+	stored := sess.Clone()
+	stored.CreatedAt = existing.CreatedAt
+	stored.UpdatedAt = time.Now()
+
+	private, user, app := splitState(stored.State)
+	stored.State = nil
+
+	s.sessions[key] = stored
+	s.private[key] = private
+	s.mergeShared(stored, user, app)
+
+	return nil
+}
+
+// mergeShared folds user- and app-scoped keys into their shared maps.
+// Caller must hold the write lock.
+func (s *InMemoryStore) mergeShared(sess *Session, user, app map[string]any) {
+	if len(user) > 0 {
+		uk := userKey(sess.OrgID, sess.UserID)
+		if s.user[uk] == nil {
+			s.user[uk] = map[string]any{}
+		}
+		for k, v := range user {
+			s.user[uk][k] = v
+		}
+	}
+	if len(app) > 0 {
+		if s.app[sess.AppName] == nil {
+			s.app[sess.AppName] = map[string]any{}
+		}
+		for k, v := range app {
+			s.app[sess.AppName][k] = v
+		}
+	}
+}
+
+// Delete implements Store.
+func (s *InMemoryStore) Delete(_ context.Context, orgID, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	key := sessionKey(orgID, id)
+	if _, ok := s.sessions[key]; !ok {
+		return fmt.Errorf("%w: %s", ErrNotFound, id)
+	}
+
+	// Only private state is removed. User- and app-scoped state belongs to
+	// other sessions too, so deleting one session must not take it with them.
+	delete(s.sessions, key)
+	delete(s.private, key)
+	return nil
+}
+
+// List implements Store.
+func (s *InMemoryStore) List(_ context.Context, filter Filter) ([]*Session, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var out []*Session
+	for _, stored := range s.sessions {
+		if filter.OrgID != "" && stored.OrgID != filter.OrgID {
+			continue
+		}
+		if filter.UserID != "" && stored.UserID != filter.UserID {
+			continue
+		}
+		meta := stored.Clone()
+		meta.State = nil
+		out = append(out, meta)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+	})
+
+	if filter.Limit > 0 && len(out) > filter.Limit {
+		out = out[:filter.Limit]
+	}
+	return out, nil
+}
+
+var _ Store = (*InMemoryStore)(nil)

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -1,0 +1,287 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/Ingenimax/agent-sdk-go/pkg/memory"
+	"github.com/Ingenimax/agent-sdk-go/pkg/multitenancy"
+)
+
+func newManager(t *testing.T) *Manager {
+	t.Helper()
+	return NewManager(NewInMemoryStore(), WithAppName("testapp"))
+}
+
+func TestCreateAndGet(t *testing.T) {
+	m := newManager(t)
+	ctx := context.Background()
+
+	created, err := m.Create(ctx, "org1", "user1")
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("Create() produced no ID")
+	}
+
+	got, err := m.Get(ctx, "org1", created.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.UserID != "user1" {
+		t.Errorf("UserID = %q, want %q", got.UserID, "user1")
+	}
+	if got.AppName != "testapp" {
+		t.Errorf("AppName = %q, want %q", got.AppName, "testapp")
+	}
+}
+
+func TestGetUnknownSession(t *testing.T) {
+	m := newManager(t)
+	if _, err := m.Get(context.Background(), "org1", "nope"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get(unknown) error = %v, want ErrNotFound", err)
+	}
+}
+
+// TestBindSuppliesTheScopingMemoryRequires is the reason sessions matter rather
+// than being decorative.
+//
+// memory.getConversationID needs BOTH an org ID and a conversation ID and hard-
+// fails without either, which is why a background or scheduled run -- having no
+// inbound request to inherit from -- could not write to memory at all.
+func TestBindSuppliesTheScopingMemoryRequires(t *testing.T) {
+	m := newManager(t)
+	ctx := context.Background()
+
+	s, err := m.Create(ctx, "org1", "user1")
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	bound := m.Bind(ctx, s)
+
+	orgID, err := multitenancy.GetOrgID(bound)
+	if err != nil {
+		t.Fatalf("GetOrgID() error = %v", err)
+	}
+	if orgID != "org1" {
+		t.Errorf("org ID = %q, want %q", orgID, "org1")
+	}
+
+	convID, ok := memory.GetConversationID(bound)
+	if !ok {
+		t.Fatal("no conversation ID on the bound context")
+	}
+	if convID != s.ID {
+		t.Errorf("conversation ID = %q, want the session ID %q", convID, s.ID)
+	}
+
+	// A bound context must actually work with memory.
+	mem := memory.NewConversationBuffer()
+	if err := mem.AddMessage(bound, interfaces.Message{
+		Role:    interfaces.MessageRoleUser,
+		Content: "hello",
+	}); err != nil {
+		t.Errorf("memory rejected a session-bound context: %v", err)
+	}
+}
+
+// TestSessionIDIsTheConversationID pins the decision not to introduce a second
+// ID space. A mapping table between session and conversation would be one more
+// thing to keep in step for no benefit.
+func TestSessionIDIsTheConversationID(t *testing.T) {
+	m := newManager(t)
+	ctx := context.Background()
+
+	s, _ := m.Create(ctx, "org1", "user1")
+	bound := m.Bind(ctx, s)
+
+	convID, _ := memory.GetConversationID(bound)
+	if convID != s.ID {
+		t.Errorf("conversation ID %q differs from session ID %q: these must be the "+
+			"same value, or a session and its transcript can drift apart", convID, s.ID)
+	}
+}
+
+func TestStatePrefixScoping(t *testing.T) {
+	store := NewInMemoryStore()
+	m := NewManager(store, WithAppName("testapp"))
+	ctx := context.Background()
+
+	first, _ := m.Create(ctx, "org1", "user1")
+	first.Set("private_key", "only mine")
+	first.Set(UserPrefix+"timezone", "Europe/Oslo")
+	first.Set(AppPrefix+"model", "gpt-4o")
+	first.Set(TempPrefix+"scratch", "discard me")
+	if err := m.Save(ctx, first); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// temp: must never survive a save.
+	reloaded, _ := m.Get(ctx, "org1", first.ID)
+	if _, ok := reloaded.Get(TempPrefix + "scratch"); ok {
+		t.Error("a temp: key was persisted; it must be dropped on save")
+	}
+	if got := reloaded.GetString("private_key"); got != "only mine" {
+		t.Errorf("private key = %q, want it preserved", got)
+	}
+
+	// user: and app: reach a different session belonging to the same user.
+	second, _ := m.Create(ctx, "org1", "user1")
+	loaded, _ := m.Get(ctx, "org1", second.ID)
+
+	if got := loaded.GetString(UserPrefix + "timezone"); got != "Europe/Oslo" {
+		t.Errorf("user-scoped key = %q, want it shared across the user's sessions", got)
+	}
+	if got := loaded.GetString(AppPrefix + "model"); got != "gpt-4o" {
+		t.Errorf("app-scoped key = %q, want it shared across the application", got)
+	}
+	if _, ok := loaded.Get("private_key"); ok {
+		t.Error("an unprefixed key leaked into another session; it must stay private")
+	}
+}
+
+func TestDeleteKeepsSharedState(t *testing.T) {
+	store := NewInMemoryStore()
+	m := NewManager(store, WithAppName("testapp"))
+	ctx := context.Background()
+
+	first, _ := m.Create(ctx, "org1", "user1")
+	first.Set(UserPrefix+"timezone", "Europe/Oslo")
+	_ = m.Save(ctx, first)
+
+	second, _ := m.Create(ctx, "org1", "user1")
+
+	if err := m.Delete(ctx, "org1", first.ID); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	loaded, err := m.Get(ctx, "org1", second.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got := loaded.GetString(UserPrefix + "timezone"); got != "Europe/Oslo" {
+		t.Error("deleting one session removed user-scoped state that belongs to " +
+			"the user's other sessions too")
+	}
+}
+
+func TestListIsScopedAndOrdered(t *testing.T) {
+	m := newManager(t)
+	ctx := context.Background()
+
+	a, _ := m.Create(ctx, "org1", "user1")
+	b, _ := m.Create(ctx, "org1", "user1")
+	_, _ = m.Create(ctx, "org1", "user2")
+	_, _ = m.Create(ctx, "org2", "user1")
+
+	// Touch b so it is the most recently updated.
+	_ = m.Save(ctx, b)
+
+	got, err := m.List(ctx, Filter{OrgID: "org1", UserID: "user1"})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("List() returned %d sessions, want 2 (scoped to org1/user1)", len(got))
+	}
+	if got[0].ID != b.ID {
+		t.Errorf("first session = %q, want the most recently updated %q", got[0].ID, b.ID)
+	}
+	_ = a
+}
+
+func TestListRespectsLimit(t *testing.T) {
+	m := newManager(t)
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		_, _ = m.Create(ctx, "org1", "user1")
+	}
+
+	got, _ := m.List(ctx, Filter{OrgID: "org1", Limit: 2})
+	if len(got) != 2 {
+		t.Errorf("List() returned %d sessions, want 2", len(got))
+	}
+}
+
+func TestForkCarriesStateNotTranscript(t *testing.T) {
+	m := newManager(t)
+	ctx := context.Background()
+
+	parent, _ := m.Create(ctx, "org1", "user1")
+	parent.Set("topic", "tide pools")
+	parent.MessageCount = 12
+	_ = m.Save(ctx, parent)
+
+	child, err := m.Fork(ctx, "org1", parent.ID)
+	if err != nil {
+		t.Fatalf("Fork() error = %v", err)
+	}
+
+	if child.ID == parent.ID {
+		t.Error("a fork must have its own ID, or it shares the parent's transcript")
+	}
+	if got := child.GetString("topic"); got != "tide pools" {
+		t.Errorf("forked state topic = %q, want it carried from the parent", got)
+	}
+	if child.MessageCount != 0 {
+		t.Errorf("MessageCount = %d, want 0: a fork starts a fresh conversation", child.MessageCount)
+	}
+	if got := child.GetString("forked_from"); got != parent.ID {
+		t.Errorf("forked_from = %q, want the parent ID", got)
+	}
+}
+
+func TestTouchDerivesTitleOnce(t *testing.T) {
+	m := newManager(t)
+	ctx := context.Background()
+
+	s, _ := m.Create(ctx, "org1", "user1")
+	if err := m.Touch(ctx, s, 2, 150, "How do tide pools form on rocky shores?"); err != nil {
+		t.Fatalf("Touch() error = %v", err)
+	}
+	if s.Title == "" {
+		t.Fatal("Touch did not derive a title from the first message")
+	}
+	first := s.Title
+
+	_ = m.Touch(ctx, s, 2, 100, "a completely different follow-up question")
+	if s.Title != first {
+		t.Errorf("title changed to %q; it should be derived once from the first message", s.Title)
+	}
+	if s.MessageCount != 4 {
+		t.Errorf("MessageCount = %d, want 4", s.MessageCount)
+	}
+	if s.TokenTotal != 250 {
+		t.Errorf("TokenTotal = %d, want 250", s.TokenTotal)
+	}
+}
+
+func TestDeriveTitleTruncatesOnAWordBoundary(t *testing.T) {
+	long := strings.Repeat("word ", 40)
+	title := DeriveTitle(long)
+
+	if len(title) > 64 {
+		t.Errorf("title is %d chars, want it truncated", len(title))
+	}
+	if strings.HasSuffix(strings.TrimSuffix(title, "…"), " ") {
+		t.Error("title should not end on a dangling space")
+	}
+	if got := DeriveTitle("short one"); got != "short one" {
+		t.Errorf("short titles should pass through unchanged; got %q", got)
+	}
+}
+
+func TestCloneIsDeep(t *testing.T) {
+	s := &Session{ID: "s1", State: map[string]any{"k": "v"}}
+	clone := s.Clone()
+	clone.Set("k", "changed")
+
+	if s.GetString("k") != "v" {
+		t.Error("mutating a clone changed the original; Clone must be deep")
+	}
+}

--- a/pkg/session/sql_store.go
+++ b/pkg/session/sql_store.go
@@ -1,0 +1,379 @@
+package session
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SQLStore persists sessions in any database/sql backend.
+//
+// It targets Postgres and SQLite, which differ in placeholder syntax ($1 versus
+// ?) and in upsert spelling. Those are the only dialect-specific details, so
+// rather than a driver interface per backend the store carries a small Dialect
+// -- the same tradeoff ADK's DatabaseSessionService makes with its
+// dialect-conditional branches.
+//
+// State is stored in three tables so the "user:" and "app:" prefixes are
+// genuinely shared rather than copied into every session row. "temp:" keys are
+// dropped before any write.
+type SQLStore struct {
+	db      *sql.DB
+	dialect Dialect
+}
+
+// Dialect names a SQL flavour.
+type Dialect string
+
+const (
+	// Postgres uses $N placeholders and ON CONFLICT upserts.
+	Postgres Dialect = "postgres"
+	// SQLite uses ? placeholders and ON CONFLICT upserts.
+	SQLite Dialect = "sqlite"
+)
+
+// NewSQLStore creates a session store over an existing *sql.DB.
+//
+// It takes a live handle rather than a DSN on purpose: a service that already
+// has a pool -- pkg/datastore/postgres, for instance -- should not open a
+// second one just for sessions.
+func NewSQLStore(db *sql.DB, dialect Dialect) (*SQLStore, error) {
+	if db == nil {
+		return nil, fmt.Errorf("session: nil *sql.DB")
+	}
+	switch dialect {
+	case Postgres, SQLite:
+	default:
+		return nil, fmt.Errorf("session: unsupported dialect %q", dialect)
+	}
+	return &SQLStore{db: db, dialect: dialect}, nil
+}
+
+// rebind rewrites a query written with ? placeholders into the dialect's form.
+func (s *SQLStore) rebind(query string) string {
+	if s.dialect != Postgres {
+		return query
+	}
+	var b strings.Builder
+	n := 0
+	for _, r := range query {
+		if r == '?' {
+			n++
+			fmt.Fprintf(&b, "$%d", n)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// Migrate creates the tables this store needs, if they do not exist.
+func (s *SQLStore) Migrate(ctx context.Context) error {
+	timestamp := "TIMESTAMPTZ"
+	if s.dialect == SQLite {
+		timestamp = "DATETIME"
+	}
+
+	statements := []string{
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS agent_sessions (
+			org_id        TEXT NOT NULL,
+			id            TEXT NOT NULL,
+			user_id       TEXT NOT NULL DEFAULT '',
+			app_name      TEXT NOT NULL DEFAULT '',
+			title         TEXT NOT NULL DEFAULT '',
+			state         TEXT NOT NULL DEFAULT '{}',
+			message_count INTEGER NOT NULL DEFAULT 0,
+			token_total   INTEGER NOT NULL DEFAULT 0,
+			created_at    %s NOT NULL,
+			updated_at    %s NOT NULL,
+			PRIMARY KEY (org_id, id)
+		)`, timestamp, timestamp),
+
+		`CREATE TABLE IF NOT EXISTS agent_session_user_state (
+			org_id  TEXT NOT NULL,
+			user_id TEXT NOT NULL,
+			state   TEXT NOT NULL DEFAULT '{}',
+			PRIMARY KEY (org_id, user_id)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS agent_session_app_state (
+			app_name TEXT NOT NULL,
+			state    TEXT NOT NULL DEFAULT '{}',
+			PRIMARY KEY (app_name)
+		)`,
+
+		`CREATE INDEX IF NOT EXISTS idx_agent_sessions_listing
+			ON agent_sessions (org_id, user_id, updated_at)`,
+	}
+
+	for _, statement := range statements {
+		if _, err := s.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("session migrate: %w", err)
+		}
+	}
+	return nil
+}
+
+// Create implements Store.
+func (s *SQLStore) Create(ctx context.Context, sess *Session) error {
+	if sess == nil || sess.ID == "" {
+		return fmt.Errorf("session requires an ID")
+	}
+
+	now := time.Now().UTC()
+	if sess.CreatedAt.IsZero() {
+		sess.CreatedAt = now
+	}
+	sess.UpdatedAt = now
+
+	private, user, app := splitState(sess.State)
+	privateJSON, err := json.Marshal(private)
+	if err != nil {
+		return fmt.Errorf("session: encoding state: %w", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, s.rebind(`
+		INSERT INTO agent_sessions
+			(org_id, id, user_id, app_name, title, state, message_count, token_total, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+		sess.OrgID, sess.ID, sess.UserID, sess.AppName, sess.Title,
+		string(privateJSON), sess.MessageCount, sess.TokenTotal,
+		sess.CreatedAt.UTC(), sess.UpdatedAt.UTC(),
+	); err != nil {
+		return fmt.Errorf("session create: %w", err)
+	}
+
+	if err := s.mergeSharedTx(ctx, tx, sess, user, app); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// Get implements Store.
+func (s *SQLStore) Get(ctx context.Context, orgID, id string) (*Session, error) {
+	row := s.db.QueryRowContext(ctx, s.rebind(`
+		SELECT user_id, app_name, title, state, message_count, token_total, created_at, updated_at
+		FROM agent_sessions WHERE org_id = ? AND id = ?`), orgID, id)
+
+	var (
+		sess      Session
+		stateJSON string
+	)
+	sess.ID = id
+	sess.OrgID = orgID
+
+	if err := row.Scan(&sess.UserID, &sess.AppName, &sess.Title, &stateJSON,
+		&sess.MessageCount, &sess.TokenTotal, &sess.CreatedAt, &sess.UpdatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, id)
+		}
+		return nil, fmt.Errorf("session get: %w", err)
+	}
+
+	private := map[string]any{}
+	if err := json.Unmarshal([]byte(stateJSON), &private); err != nil {
+		return nil, fmt.Errorf("session: decoding state: %w", err)
+	}
+
+	user, err := s.readSharedState(ctx, `SELECT state FROM agent_session_user_state WHERE org_id = ? AND user_id = ?`, orgID, sess.UserID)
+	if err != nil {
+		return nil, err
+	}
+	app, err := s.readSharedState(ctx, `SELECT state FROM agent_session_app_state WHERE app_name = ?`, sess.AppName)
+	if err != nil {
+		return nil, err
+	}
+
+	sess.State = mergeState(private, user, app)
+	return &sess, nil
+}
+
+func (s *SQLStore) readSharedState(ctx context.Context, query string, args ...any) (map[string]any, error) {
+	var stateJSON string
+	err := s.db.QueryRowContext(ctx, s.rebind(query), args...).Scan(&stateJSON)
+	if err == sql.ErrNoRows {
+		return map[string]any{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("session: reading shared state: %w", err)
+	}
+
+	state := map[string]any{}
+	if err := json.Unmarshal([]byte(stateJSON), &state); err != nil {
+		return nil, fmt.Errorf("session: decoding shared state: %w", err)
+	}
+	return state, nil
+}
+
+// Update implements Store.
+func (s *SQLStore) Update(ctx context.Context, sess *Session) error {
+	if sess == nil || sess.ID == "" {
+		return fmt.Errorf("session requires an ID")
+	}
+
+	sess.UpdatedAt = time.Now().UTC()
+
+	private, user, app := splitState(sess.State)
+	privateJSON, err := json.Marshal(private)
+	if err != nil {
+		return fmt.Errorf("session: encoding state: %w", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	result, err := tx.ExecContext(ctx, s.rebind(`
+		UPDATE agent_sessions
+		SET user_id = ?, app_name = ?, title = ?, state = ?,
+		    message_count = ?, token_total = ?, updated_at = ?
+		WHERE org_id = ? AND id = ?`),
+		sess.UserID, sess.AppName, sess.Title, string(privateJSON),
+		sess.MessageCount, sess.TokenTotal, sess.UpdatedAt.UTC(),
+		sess.OrgID, sess.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("session update: %w", err)
+	}
+	if affected, err := result.RowsAffected(); err == nil && affected == 0 {
+		return fmt.Errorf("%w: %s", ErrNotFound, sess.ID)
+	}
+
+	if err := s.mergeSharedTx(ctx, tx, sess, user, app); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// mergeSharedTx folds user- and app-scoped keys into their shared rows.
+//
+// The read-modify-write happens inside the caller's transaction so two sessions
+// writing different user-scoped keys concurrently cannot lose one of them.
+func (s *SQLStore) mergeSharedTx(ctx context.Context, tx *sql.Tx, sess *Session, user, app map[string]any) error {
+	if len(user) > 0 && sess.UserID != "" {
+		merged, err := s.mergeIntoRowTx(ctx, tx,
+			`SELECT state FROM agent_session_user_state WHERE org_id = ? AND user_id = ?`,
+			user, sess.OrgID, sess.UserID)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, s.rebind(`
+			INSERT INTO agent_session_user_state (org_id, user_id, state) VALUES (?, ?, ?)
+			ON CONFLICT (org_id, user_id) DO UPDATE SET state = EXCLUDED.state`),
+			sess.OrgID, sess.UserID, merged); err != nil {
+			return fmt.Errorf("session: writing user state: %w", err)
+		}
+	}
+
+	if len(app) > 0 && sess.AppName != "" {
+		merged, err := s.mergeIntoRowTx(ctx, tx,
+			`SELECT state FROM agent_session_app_state WHERE app_name = ?`,
+			app, sess.AppName)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, s.rebind(`
+			INSERT INTO agent_session_app_state (app_name, state) VALUES (?, ?)
+			ON CONFLICT (app_name) DO UPDATE SET state = EXCLUDED.state`),
+			sess.AppName, merged); err != nil {
+			return fmt.Errorf("session: writing app state: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *SQLStore) mergeIntoRowTx(ctx context.Context, tx *sql.Tx, query string, incoming map[string]any, args ...any) (string, error) {
+	existing := map[string]any{}
+
+	var stateJSON string
+	err := tx.QueryRowContext(ctx, s.rebind(query), args...).Scan(&stateJSON)
+	if err != nil && err != sql.ErrNoRows {
+		return "", fmt.Errorf("session: reading shared state: %w", err)
+	}
+	if err == nil {
+		if err := json.Unmarshal([]byte(stateJSON), &existing); err != nil {
+			return "", fmt.Errorf("session: decoding shared state: %w", err)
+		}
+	}
+
+	for k, v := range incoming {
+		existing[k] = v
+	}
+
+	encoded, err := json.Marshal(existing)
+	if err != nil {
+		return "", fmt.Errorf("session: encoding shared state: %w", err)
+	}
+	return string(encoded), nil
+}
+
+// Delete implements Store.
+func (s *SQLStore) Delete(ctx context.Context, orgID, id string) error {
+	// Only the session row goes. User- and app-scoped state is shared with
+	// other sessions, so deleting one must not take it with them.
+	result, err := s.db.ExecContext(ctx, s.rebind(
+		`DELETE FROM agent_sessions WHERE org_id = ? AND id = ?`), orgID, id)
+	if err != nil {
+		return fmt.Errorf("session delete: %w", err)
+	}
+	if affected, err := result.RowsAffected(); err == nil && affected == 0 {
+		return fmt.Errorf("%w: %s", ErrNotFound, id)
+	}
+	return nil
+}
+
+// List implements Store.
+func (s *SQLStore) List(ctx context.Context, filter Filter) ([]*Session, error) {
+	query := `SELECT org_id, id, user_id, app_name, title, message_count, token_total, created_at, updated_at
+	          FROM agent_sessions`
+	var conditions []string
+	var args []any
+
+	if filter.OrgID != "" {
+		conditions = append(conditions, "org_id = ?")
+		args = append(args, filter.OrgID)
+	}
+	if filter.UserID != "" {
+		conditions = append(conditions, "user_id = ?")
+		args = append(args, filter.UserID)
+	}
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	query += " ORDER BY updated_at DESC"
+	if filter.Limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", filter.Limit)
+	}
+
+	rows, err := s.db.QueryContext(ctx, s.rebind(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("session list: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*Session
+	for rows.Next() {
+		var sess Session
+		if err := rows.Scan(&sess.OrgID, &sess.ID, &sess.UserID, &sess.AppName,
+			&sess.Title, &sess.MessageCount, &sess.TokenTotal,
+			&sess.CreatedAt, &sess.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("session list: %w", err)
+		}
+		out = append(out, &sess)
+	}
+	return out, rows.Err()
+}
+
+var _ Store = (*SQLStore)(nil)

--- a/pkg/skill/skill.go
+++ b/pkg/skill/skill.go
@@ -1,0 +1,341 @@
+// Package skill loads SKILL.md capability bundles from disk and exposes them to
+// an agent.
+//
+// A skill is a folder holding a SKILL.md whose YAML frontmatter carries at
+// least a name and a description, followed by markdown instructions and
+// optional bundled resources:
+//
+//	skills/
+//	  incident-triage/
+//	    SKILL.md
+//	    runbook.md
+//	    queries/slow-requests.sql
+//
+// # Progressive disclosure
+//
+// Only each skill's name and description sit in the model's context. The
+// instructions load when the model chooses a skill and calls load_skill. That
+// property is the whole point: twenty skills cost twenty one-line descriptions
+// rather than twenty documents, so a large library stays affordable.
+//
+// # What this package will not do
+//
+// It does not execute anything. A skill is instructions and reference material;
+// bundled files are read, never run. A format that silently executes code from
+// a folder someone cloned is a supply-chain problem, and loading a skill is not
+// a decision a user makes consciously enough to carry that risk.
+package skill
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Skill is one loaded capability bundle.
+type Skill struct {
+	// Name identifies the skill to the model. Required.
+	Name string `yaml:"name"`
+
+	// Description tells the model when to use it. Required, and the only part
+	// besides the name that is always in context -- so it is what determines
+	// whether the skill is ever chosen.
+	Description string `yaml:"description"`
+
+	// Version is optional metadata.
+	Version string `yaml:"version,omitempty"`
+
+	// Tags are optional grouping labels.
+	Tags []string `yaml:"tags,omitempty"`
+
+	// Instructions is the markdown body, loaded on demand.
+	Instructions string `yaml:"-"`
+
+	// Dir is the skill's directory on disk.
+	Dir string `yaml:"-"`
+
+	// Resources are the bundled files, relative to Dir.
+	Resources []string `yaml:"-"`
+}
+
+// Validate reports whether a skill is usable.
+func (s *Skill) Validate() error {
+	if strings.TrimSpace(s.Name) == "" {
+		return fmt.Errorf("skill requires a name")
+	}
+	if strings.TrimSpace(s.Description) == "" {
+		// Without a description the model has nothing to select on, so the
+		// skill can never be chosen. Better to reject it at load than to ship a
+		// library with a silently unreachable entry.
+		return fmt.Errorf("skill %q requires a description", s.Name)
+	}
+	return nil
+}
+
+// Library is a set of loaded skills.
+type Library struct {
+	mu     sync.RWMutex
+	skills map[string]*Skill
+	order  []string
+}
+
+// NewLibrary creates an empty library.
+func NewLibrary() *Library {
+	return &Library{skills: map[string]*Skill{}}
+}
+
+// Add puts a skill in the library, replacing any skill of the same name.
+func (l *Library) Add(s *Skill) error {
+	if err := s.Validate(); err != nil {
+		return err
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if _, exists := l.skills[s.Name]; !exists {
+		l.order = append(l.order, s.Name)
+	}
+	l.skills[s.Name] = s
+	return nil
+}
+
+// Get returns a skill by name.
+func (l *Library) Get(name string) (*Skill, bool) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	s, ok := l.skills[name]
+	return s, ok
+}
+
+// List returns every skill, in load order.
+func (l *Library) List() []*Skill {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	out := make([]*Skill, 0, len(l.order))
+	for _, name := range l.order {
+		out = append(out, l.skills[name])
+	}
+	return out
+}
+
+// Len returns how many skills are loaded.
+func (l *Library) Len() int {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return len(l.skills)
+}
+
+// Catalog renders the name-and-description index that sits in the model's
+// context.
+//
+// This is the entire context cost of a skill library until one is invoked.
+func (l *Library) Catalog() string {
+	skills := l.List()
+	if len(skills) == 0 {
+		return "No skills are available."
+	}
+
+	var b strings.Builder
+	b.WriteString("Available skills. Call load_skill with a name to read its full instructions.\n\n")
+	for _, s := range skills {
+		fmt.Fprintf(&b, "- %s: %s\n", s.Name, s.Description)
+	}
+	return b.String()
+}
+
+// LoadDir loads every skill under root.
+//
+// A directory containing a SKILL.md is a skill. Directories are walked one
+// level deep, which matches how skill collections are laid out in practice and
+// avoids surprising recursion into unrelated trees.
+func LoadDir(root string) (*Library, error) {
+	lib := NewLibrary()
+	if err := lib.LoadDir(root); err != nil {
+		return nil, err
+	}
+	return lib, nil
+}
+
+// LoadDir adds every skill under root to the library.
+func (l *Library) LoadDir(root string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return fmt.Errorf("reading skills directory: %w", err)
+	}
+
+	var failures []string
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		dir := filepath.Join(root, entry.Name())
+		manifest := filepath.Join(dir, "SKILL.md")
+		if _, err := os.Stat(manifest); err != nil {
+			continue // not a skill directory
+		}
+
+		s, err := LoadFile(manifest)
+		if err != nil {
+			// One malformed skill should not make the rest unavailable, but the
+			// failure must be reported rather than swallowed.
+			failures = append(failures, fmt.Sprintf("%s: %v", entry.Name(), err))
+			continue
+		}
+		if err := l.Add(s); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", entry.Name(), err))
+		}
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("some skills failed to load: %s", strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+// LoadFile loads a single SKILL.md.
+func LoadFile(path string) (*Skill, error) {
+	// #nosec G304 -- path comes from a directory walk the operator pointed at,
+	// or from an explicit caller argument.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading skill: %w", err)
+	}
+
+	s, err := Parse(string(data))
+	if err != nil {
+		return nil, err
+	}
+
+	s.Dir = filepath.Dir(path)
+	s.Resources, err = listResources(s.Dir)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Parse reads a SKILL.md's frontmatter and body.
+func Parse(content string) (*Skill, error) {
+	frontmatter, body, err := splitFrontmatter(content)
+	if err != nil {
+		return nil, err
+	}
+
+	var s Skill
+	if err := yaml.Unmarshal([]byte(frontmatter), &s); err != nil {
+		return nil, fmt.Errorf("parsing skill frontmatter: %w", err)
+	}
+
+	s.Instructions = strings.TrimSpace(body)
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// splitFrontmatter separates a leading `---` delimited YAML block from the body.
+func splitFrontmatter(content string) (frontmatter, body string, err error) {
+	trimmed := strings.TrimLeft(content, " \t\r\n")
+	if !strings.HasPrefix(trimmed, "---") {
+		return "", "", fmt.Errorf("skill is missing YAML frontmatter: expected a leading '---' block")
+	}
+
+	rest := strings.TrimPrefix(trimmed, "---")
+	rest = strings.TrimLeft(rest, "\r\n")
+
+	idx := strings.Index(rest, "\n---")
+	if idx < 0 {
+		return "", "", fmt.Errorf("skill frontmatter is not closed: expected a trailing '---'")
+	}
+
+	frontmatter = rest[:idx]
+	body = rest[idx+len("\n---"):]
+	body = strings.TrimLeft(body, "-")
+	return frontmatter, body, nil
+}
+
+// listResources returns the bundled files in a skill directory, excluding the
+// manifest itself.
+func listResources(dir string) ([]string, error) {
+	var resources []string
+
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel == "SKILL.md" {
+			return nil
+		}
+		resources = append(resources, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing skill resources: %w", err)
+	}
+
+	sort.Strings(resources)
+	return resources, nil
+}
+
+// ReadResource returns a bundled file's contents.
+//
+// The path is confined to the skill's directory: a resource name that escapes
+// it, by traversal or symlink, is refused. A skill folder arrives by git clone,
+// so treating its contents as trusted paths would let one read arbitrary files
+// off the host.
+func (s *Skill) ReadResource(name string) (string, error) {
+	if s.Dir == "" {
+		return "", fmt.Errorf("skill %q has no directory", s.Name)
+	}
+
+	root, err := filepath.Abs(s.Dir)
+	if err != nil {
+		return "", err
+	}
+	// Resolve the ROOT too, not just the target. On macOS a temp directory is
+	// itself a symlink (/var -> /private/var), so comparing a resolved target
+	// against an unresolved root rejects perfectly legitimate paths. This is the
+	// same defect that makes prompts.isPathSafe unsound in the other direction.
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+
+	target, err := filepath.Abs(filepath.Join(root, name))
+	if err != nil {
+		return "", err
+	}
+
+	// Resolve symlinks before the containment check, or a link inside the
+	// directory can point anywhere.
+	if resolved, err := filepath.EvalSymlinks(target); err == nil {
+		target = resolved
+	}
+
+	rel, err := filepath.Rel(root, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("resource %q is outside skill %q", name, s.Name)
+	}
+
+	// #nosec G304 -- containment verified immediately above.
+	data, err := os.ReadFile(target)
+	if err != nil {
+		return "", fmt.Errorf("reading resource %q: %w", name, err)
+	}
+	return string(data), nil
+}

--- a/pkg/skill/skill_test.go
+++ b/pkg/skill/skill_test.go
@@ -1,0 +1,331 @@
+package skill
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writeSkill(t *testing.T, root, name, content string, resources map[string]string) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	for path, body := range resources {
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+	return dir
+}
+
+const triageSkill = `---
+name: incident-triage
+description: Triage a production incident and identify the failing component
+version: "1.2"
+tags: [ops, oncall]
+---
+
+# Triage
+
+1. Check the error rate dashboard.
+2. Correlate with recent deploys.
+`
+
+func TestParseReadsFrontmatterAndBody(t *testing.T) {
+	s, err := Parse(triageSkill)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if s.Name != "incident-triage" {
+		t.Errorf("Name = %q", s.Name)
+	}
+	if !strings.Contains(s.Description, "Triage a production incident") {
+		t.Errorf("Description = %q", s.Description)
+	}
+	if s.Version != "1.2" {
+		t.Errorf("Version = %q, want %q", s.Version, "1.2")
+	}
+	if len(s.Tags) != 2 {
+		t.Errorf("Tags = %v, want two", s.Tags)
+	}
+	if !strings.Contains(s.Instructions, "error rate dashboard") {
+		t.Errorf("Instructions did not capture the body: %q", s.Instructions)
+	}
+	if strings.Contains(s.Instructions, "description:") {
+		t.Error("frontmatter leaked into the instructions")
+	}
+}
+
+func TestParseRejectsMissingFrontmatter(t *testing.T) {
+	if _, err := Parse("# Just markdown\n"); err == nil {
+		t.Error("a skill without frontmatter should be rejected")
+	}
+}
+
+func TestParseRejectsUnclosedFrontmatter(t *testing.T) {
+	if _, err := Parse("---\nname: x\ndescription: y\n"); err == nil {
+		t.Error("unclosed frontmatter should be rejected")
+	}
+}
+
+// TestDescriptionIsRequired guards a subtle failure: a skill with no
+// description can never be selected by the model, so it would sit in the
+// library permanently unreachable.
+func TestDescriptionIsRequired(t *testing.T) {
+	_, err := Parse("---\nname: nameless\n---\nbody\n")
+	if err == nil {
+		t.Fatal("a skill without a description should be rejected")
+	}
+	if !strings.Contains(err.Error(), "description") {
+		t.Errorf("error = %v, want it to name the missing field", err)
+	}
+}
+
+func TestLoadDirLoadsEverySkill(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "incident-triage", triageSkill, nil)
+	writeSkill(t, root, "release-notes", `---
+name: release-notes
+description: Draft release notes from a changelog
+---
+Write them.
+`, nil)
+	// A directory without a SKILL.md is not a skill and must be skipped.
+	if err := os.MkdirAll(filepath.Join(root, "not-a-skill"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	lib, err := LoadDir(root)
+	if err != nil {
+		t.Fatalf("LoadDir() error = %v", err)
+	}
+	if lib.Len() != 2 {
+		t.Errorf("loaded %d skills, want 2", lib.Len())
+	}
+	if _, ok := lib.Get("incident-triage"); !ok {
+		t.Error("incident-triage was not loaded")
+	}
+}
+
+func TestLoadDirReportsBadSkillsWithoutLosingGoodOnes(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "good", triageSkill, nil)
+	writeSkill(t, root, "bad", "no frontmatter here", nil)
+
+	lib := NewLibrary()
+	err := lib.LoadDir(root)
+
+	if err == nil {
+		t.Error("a malformed skill should be reported")
+	}
+	if lib.Len() != 1 {
+		t.Errorf("loaded %d skills, want the one good skill to survive", lib.Len())
+	}
+}
+
+// TestCatalogIsTheWholeContextCost is the property that makes a large skill
+// library affordable: only names and descriptions are in context until a skill
+// is actually invoked.
+func TestCatalogIsTheWholeContextCost(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "incident-triage", triageSkill, nil)
+	lib, _ := LoadDir(root)
+
+	catalog := lib.Catalog()
+
+	if !strings.Contains(catalog, "incident-triage") {
+		t.Error("the catalog should name each skill")
+	}
+	if !strings.Contains(catalog, "Triage a production incident") {
+		t.Error("the catalog should carry each description")
+	}
+	if strings.Contains(catalog, "error rate dashboard") {
+		t.Error("the catalog leaked a skill's full instructions; only the name " +
+			"and description belong in context until load_skill is called")
+	}
+}
+
+func TestLoadSkillToolReturnsInstructionsOnDemand(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "incident-triage", triageSkill, map[string]string{
+		"runbook.md": "# Runbook\nRestart the thing.",
+	})
+	lib, _ := LoadDir(root)
+
+	tools := Tools(lib)
+	if len(tools) != 2 {
+		t.Fatalf("Tools() returned %d tools, want 2", len(tools))
+	}
+
+	out, err := tools[0].Execute(context.Background(), `{"name":"incident-triage"}`)
+	if err != nil {
+		t.Fatalf("load_skill error = %v", err)
+	}
+	if !strings.Contains(out, "error rate dashboard") {
+		t.Error("load_skill did not return the instructions")
+	}
+	if !strings.Contains(out, "runbook.md") {
+		t.Error("load_skill should list the bundled resources")
+	}
+}
+
+func TestLoadSkillToolConstrainsNamesToTheLibrary(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "incident-triage", triageSkill, nil)
+	lib, _ := LoadDir(root)
+
+	spec := Tools(lib)[0].Parameters()["name"]
+	if len(spec.Enum) != 1 {
+		t.Fatalf("name enum = %v, want exactly the loaded skill", spec.Enum)
+	}
+	if spec.Enum[0] != "incident-triage" {
+		t.Errorf("enum = %v, want the skill name", spec.Enum)
+	}
+}
+
+func TestUnknownSkillIsRecoverable(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "incident-triage", triageSkill, nil)
+	lib, _ := LoadDir(root)
+
+	out, err := Tools(lib)[0].Execute(context.Background(), `{"name":"does-not-exist"}`)
+	if err != nil {
+		t.Fatalf("an unknown skill should not fail the run: %v", err)
+	}
+	if !strings.Contains(out, "incident-triage") {
+		t.Error("the response should list what does exist, so the turn is recoverable")
+	}
+}
+
+func TestReadResourceReturnsBundledFiles(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "incident-triage", triageSkill, map[string]string{
+		"queries/slow.sql": "SELECT 1;",
+	})
+	lib, _ := LoadDir(root)
+
+	args, _ := json.Marshal(map[string]string{"skill": "incident-triage", "path": "queries/slow.sql"})
+	out, err := Tools(lib)[1].Execute(context.Background(), string(args))
+	if err != nil {
+		t.Fatalf("read_skill_resource error = %v", err)
+	}
+	if out != "SELECT 1;" {
+		t.Errorf("resource content = %q, want the file's contents", out)
+	}
+}
+
+// TestResourceTraversalIsRefused guards a real attack surface: a skill folder
+// arrives by git clone, so treating its resource names as trusted paths would
+// let one read arbitrary files off the host.
+func TestResourceTraversalIsRefused(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "evil", `---
+name: evil
+description: tries to escape its directory
+---
+body
+`, nil)
+
+	// A secret outside the skill directory.
+	secret := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOP SECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	lib, _ := LoadDir(root)
+	s, _ := lib.Get("evil")
+
+	for _, attempt := range []string{
+		"../secret.txt",
+		"../../etc/passwd",
+		"subdir/../../secret.txt",
+	} {
+		if content, err := s.ReadResource(attempt); err == nil {
+			t.Errorf("ReadResource(%q) succeeded and returned %q; traversal must be refused",
+				attempt, content)
+		}
+	}
+}
+
+// TestResourceSymlinkEscapeIsRefused covers the subtler form: a link inside the
+// directory pointing outside it.
+func TestResourceSymlinkEscapeIsRefused(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+
+	root := t.TempDir()
+	dir := writeSkill(t, root, "linky", `---
+name: linky
+description: contains a symlink pointing outside
+---
+body
+`, nil)
+
+	secret := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(secret, []byte("TOP SECRET"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(dir, "link.txt")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	lib := NewLibrary()
+	_ = lib.LoadDir(root)
+	s, ok := lib.Get("linky")
+	if !ok {
+		t.Fatal("skill did not load")
+	}
+
+	if content, err := s.ReadResource("link.txt"); err == nil {
+		t.Errorf("a symlink escaping the skill directory was followed, returning %q", content)
+	}
+}
+
+func TestReadResourceRejectsUnknownFile(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "incident-triage", triageSkill, nil)
+	lib, _ := LoadDir(root)
+
+	args, _ := json.Marshal(map[string]string{"skill": "incident-triage", "path": "nope.md"})
+	out, err := Tools(lib)[1].Execute(context.Background(), string(args))
+	if err != nil {
+		t.Fatalf("a missing resource should not fail the run: %v", err)
+	}
+	if !strings.Contains(out, "Could not read") {
+		t.Errorf("response = %q, want a readable explanation", out)
+	}
+}
+
+func TestAddReplacesSkillOfTheSameName(t *testing.T) {
+	lib := NewLibrary()
+	_ = lib.Add(&Skill{Name: "x", Description: "first"})
+	_ = lib.Add(&Skill{Name: "x", Description: "second"})
+
+	if lib.Len() != 1 {
+		t.Errorf("Len() = %d, want 1", lib.Len())
+	}
+	s, _ := lib.Get("x")
+	if s.Description != "second" {
+		t.Errorf("Description = %q, want the replacement", s.Description)
+	}
+}
+
+func TestEmptyLibraryCatalogIsHonest(t *testing.T) {
+	if got := NewLibrary().Catalog(); !strings.Contains(got, "No skills") {
+		t.Errorf("Catalog() = %q, want it to say there are none", got)
+	}
+}

--- a/pkg/skill/tools.go
+++ b/pkg/skill/tools.go
@@ -1,0 +1,147 @@
+package skill
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+// Tools returns the tools that expose a library to a model.
+//
+// Two tools, deliberately: one to read a skill's instructions, one to read a
+// bundled file. Registering a tool per skill instead would put every skill's
+// full schema in context on every request, which is exactly the cost
+// progressive disclosure exists to avoid.
+func Tools(lib *Library) []interfaces.Tool {
+	return []interfaces.Tool{
+		&loadSkillTool{lib: lib},
+		&readResourceTool{lib: lib},
+	}
+}
+
+// loadSkillTool returns a skill's full instructions.
+type loadSkillTool struct{ lib *Library }
+
+func (t *loadSkillTool) Name() string { return "load_skill" }
+
+func (t *loadSkillTool) Description() string {
+	var b strings.Builder
+	b.WriteString("Load the full instructions for a skill. ")
+	b.WriteString(t.lib.Catalog())
+	return b.String()
+}
+
+func (t *loadSkillTool) Parameters() map[string]interfaces.ParameterSpec {
+	names := make([]interface{}, 0, t.lib.Len())
+	for _, s := range t.lib.List() {
+		names = append(names, s.Name)
+	}
+
+	spec := interfaces.ParameterSpec{
+		Type:        "string",
+		Description: "The name of the skill to load",
+		Required:    true,
+	}
+	// Constraining to the known names stops the model inventing a skill that
+	// does not exist, which otherwise costs a whole turn to discover.
+	if len(names) > 0 {
+		spec.Enum = names
+	}
+
+	return map[string]interfaces.ParameterSpec{"name": spec}
+}
+
+func (t *loadSkillTool) Run(ctx context.Context, input string) (string, error) {
+	return t.Execute(ctx, input)
+}
+
+func (t *loadSkillTool) Execute(_ context.Context, args string) (string, error) {
+	var params struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(args), &params); err != nil {
+		return "", fmt.Errorf("parsing arguments: %w", err)
+	}
+	if params.Name == "" {
+		return "", fmt.Errorf("a skill name is required")
+	}
+
+	s, ok := t.lib.Get(params.Name)
+	if !ok {
+		// Listing what does exist turns a dead end into a recoverable turn.
+		return fmt.Sprintf("No skill named %q. %s", params.Name, t.lib.Catalog()), nil
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Skill: %s\n\n%s\n", s.Name, s.Instructions)
+
+	if len(s.Resources) > 0 {
+		b.WriteString("\n## Bundled resources\n\n")
+		for _, r := range s.Resources {
+			fmt.Fprintf(&b, "- %s\n", r)
+		}
+		b.WriteString("\nCall read_skill_resource to read one.\n")
+	}
+
+	return b.String(), nil
+}
+
+// readResourceTool returns a file bundled with a skill.
+type readResourceTool struct{ lib *Library }
+
+func (t *readResourceTool) Name() string { return "read_skill_resource" }
+
+func (t *readResourceTool) Description() string {
+	return "Read a file bundled with a skill. Call load_skill first to see what a skill provides."
+}
+
+func (t *readResourceTool) Parameters() map[string]interfaces.ParameterSpec {
+	return map[string]interfaces.ParameterSpec{
+		"skill": {
+			Type:        "string",
+			Description: "The skill that owns the resource",
+			Required:    true,
+		},
+		"path": {
+			Type:        "string",
+			Description: "The resource path, as listed by load_skill",
+			Required:    true,
+		},
+	}
+}
+
+func (t *readResourceTool) Run(ctx context.Context, input string) (string, error) {
+	return t.Execute(ctx, input)
+}
+
+func (t *readResourceTool) Execute(_ context.Context, args string) (string, error) {
+	var params struct {
+		Skill string `json:"skill"`
+		Path  string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(args), &params); err != nil {
+		return "", fmt.Errorf("parsing arguments: %w", err)
+	}
+
+	s, ok := t.lib.Get(params.Skill)
+	if !ok {
+		return fmt.Sprintf("No skill named %q.", params.Skill), nil
+	}
+
+	content, err := s.ReadResource(params.Path)
+	if err != nil {
+		// Reported to the model rather than failing the run: a wrong path is a
+		// recoverable mistake, and the resource list is right there.
+		return fmt.Sprintf("Could not read %q from skill %q: %v", params.Path, params.Skill, err), nil
+	}
+
+	return content, nil
+}
+
+var (
+	_ interfaces.Tool = (*loadSkillTool)(nil)
+	_ interfaces.Tool = (*readResourceTool)(nil)
+)


### PR DESCRIPTION
## Summary

Builds the seven capabilities that were designed but unbuilt: sessions, hooks/plugins, skills, consolidation, `pkg/run`, prompt caching beyond Anthropic, and LLM-driven transfer.

**Stacked on #357** — it depends on the tool-decorator seam, the memory-unwrap helpers and `internal/testutil` from that PR. Merge #357 first.

| Package | What it adds |
| --- | --- |
| `pkg/session` | Conversation identity, prefix-scoped state, in-memory + Postgres/SQLite stores |
| `pkg/run` | Run IDs, a registry, cancel-by-ID, detached background runs |
| `pkg/hooks` | Lifecycle callbacks bundled as named plugins, + 6 built-ins |
| `pkg/skill` | SKILL.md bundles with progressive disclosure |
| `pkg/consolidation` | Idle distillation of memory into durable facts |
| `pkg/llm/cachepolicy` | Per-provider caching capability, + cached-token reporting for OpenAI/Azure |
| `pkg/orchestration` | `transfer_to_agent` with an enum-constrained target |

## The blocking question, resolved

Review flagged that `pkg/run` risked being a **fourth** overlapping notion of work alongside `pkg/task`, `pkg/executionplan` and `orchestration.Workflow`.

Checked, and it is not. `pkg/task` is a task *lifecycle* service — `CreateTask`, `ApproveTaskPlan`, `AddTaskLog` — concerning work a person tracks over time, with no run identity and no cancel-by-ID for agent runs. `pkg/run` concerns a single invocation in flight right now. Neither is built on the other, and the package doc says so, so a future reader does not re-derive it.

## Decisions worth reviewing

Each of these has a plausible opposite, so they are the places to push back.

**Sessions.** `Session.ID` *is* the conversation ID — no second ID space, no mapping table, so a session and its transcript cannot drift. A session does not own the transcript; `pkg/memory` already stores it under the same key. `Bind` is the load-bearing call: memory hard-fails without both an org and a conversation ID, which is exactly why background and scheduled runs could not write to memory at all.

**Runs.** `WithDetached` is opt-in — a run started in an HTTP handler otherwise dies on client disconnect, but detaching by default would make every run outlive its request. `FromContext` returns the run **ID**, not the handle: a handle is mutable and reachable from arbitrary tool code, including MCP tools backed by remote processes, which could then mark a run succeeded or forge its result.

**Hooks.** The zero `Outcome` **allows** — a hook returning early must not block every tool. A denial is a **result, not an error**, because providers turn a tool error into a tool-result message and continue anyway. A panic in `BeforeTool` fails the call; in `AfterTool` it does not — a pre-hook gates execution, a post-hook is observational and must not discard a result already produced.

**Skills.** Nothing is executed. Bundled files are read, never run — a format that silently runs code from a cloned folder is a supply-chain problem. Resource reads are confined to the skill directory; traversal and symlink escape are both refused and tested.

**Consolidation.** It **proposes**; it does not rewrite. `Plan` writes nothing, `Apply` is separate, and the scheduler does not apply without `WithAutoApply`. Memory is the record of what was said, and a model quietly rewriting it — no diff, no provenance, no undo — should be a deliberate choice. Facts go to a separate store; the transcript is never mutated, and a test asserts it.

**Caching.** Control and reporting are tracked **separately**, because OpenAI has no control surface yet reports cache reads — a single "supports caching" boolean would misrepresent it. `CheckConfig` turns an inert setting into a startup error rather than something discovered from a flat bill.

## Two bugs the tests found while writing them

**`WithIdleFor(0)` was silently ignored** by a `d > 0` guard — so "consolidate whatever is eligible now", exactly what an external scheduler wants in a multi-replica deployment, was unconfigurable.

**Skill resource containment rejected legitimate paths.** Resolving symlinks on the target but not the root broke nested resources, because macOS temp dirs are themselves symlinks. Same defect class as the existing `prompts.isPathSafe`, which compares against a `basePath` it never absolutizes — failing open rather than closed.

## Verification

`go vet ./...`, `go test -race -count=1 ./...`, `golangci-lint run ./...` (0 issues) and gosec all clean.

Every code sample in `docs/capabilities.md` was compile-checked against the real API by extracting them into a file built against the module.

## Deliberately not included

`pkg/session` ships in-memory and SQL stores; there is no Vertex AI session service. That needs live Vertex credentials to develop against and would be untested here, which is worse than absent.

Gemini's explicit cached-content API is likewise recorded in the capability matrix as unsupported rather than half-wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
